### PR TITLE
feat: add .env file support with --dotenv flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# PromptCanary environment variables
+# Copy this file to .env and fill in your keys:
+#   cp .env.example .env
+#
+# .env is gitignored and will never be committed.
+# dotenv does NOT overwrite variables already set in your shell.
+
+# Required: at least one LLM provider key
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+
+# Optional: used for semantic similarity checks (defaults to OpenAI)
+# OPENAI_API_KEY is reused if embedding_provider.api_key_env is set to OPENAI_API_KEY
+
+# Optional: Slack alerting
+# SLACK_WEBHOOK_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ dist/
 *.db
 .env
 .env.*
+!.env.example
 coverage/
 *.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -34,12 +34,63 @@ Install globally to use the `promptcanary` command anywhere:
 npm install -g promptcanary
 ```
 
+## API Keys
+
+PromptCanary reads API keys from environment variables. Choose the approach that fits your environment:
+
+### Local development (`.env` file)
+
+The CLI auto-loads a `.env` file from the current directory. Copy the template and fill in your keys:
+
+```bash
+cp .env.example .env
+# Edit .env with your keys
+promptcanary run promptcanary.yaml
+```
+
+`.env` is gitignored and never committed. dotenv will not overwrite variables already set in your shell.
+
+To load a `.env` file from a different location (e.g. outside your repo for extra security):
+
+```bash
+promptcanary --dotenv ~/.config/promptcanary/.env run promptcanary.yaml
+```
+
+### Shell profile (more secure locally)
+
+Set keys in your shell profile (`~/.bashrc`, `~/.zshrc`, or PowerShell `$PROFILE`) so they never exist in a project file that AI coding tools or other programs could read:
+
+```bash
+# ~/.bashrc or ~/.zshrc
+export OPENAI_API_KEY="sk-..."
+export ANTHROPIC_API_KEY="sk-ant-..."
+```
+
+### CI/CD
+
+Use your CI provider's secrets management. Keys are injected as environment variables at runtime and never touch disk:
+
+```yaml
+# GitHub Actions
+- run: promptcanary run promptcanary.yaml
+  env:
+    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+```
+
+### Production / Docker
+
+Pass keys via environment variables. Use your platform's secret management (AWS Secrets Manager, Vault, Doppler, etc.):
+
+```bash
+docker run -e OPENAI_API_KEY="$OPENAI_API_KEY" promptcanary run config.yaml
+```
+
 ## Configuration Reference
 
 PromptCanary uses a YAML config file (typically `promptcanary.yaml`) with this structure:
 
 ```yaml
-version: "1"
+version: '1'
 
 config:
   providers:
@@ -50,7 +101,7 @@ config:
       max_tokens: 300
       timeout_ms: 30000
 
-  schedule: "0 */6 * * *"
+  schedule: '0 */6 * * *'
 
   alerts:
     - type: slack
@@ -65,8 +116,8 @@ config:
     model: text-embedding-3-small
 
 tests:
-  - name: "Professional greeting"
-    prompt: "Say hello in a professional way"
+  - name: 'Professional greeting'
+    prompt: 'Say hello in a professional way'
     variables:
       company: PromptCanary
     providers: [openai]
@@ -74,11 +125,11 @@ tests:
       format: plain_text
       min_length: 20
       max_length: 200
-      must_contain: ["hello"]
-      must_not_contain: ["error"]
+      must_contain: ['hello']
+      must_not_contain: ['error']
       tone: professional
       semantic_similarity:
-        baseline: "Hello and welcome. How can I help you today?"
+        baseline: 'Hello and welcome. How can I help you today?'
         threshold: 0.8
 ```
 
@@ -144,6 +195,7 @@ Flags:
 
 - `--json`: Output machine-readable JSON.
 - `--verbose`: Print progress for each provider execution.
+- `--dotenv <path>`: Load environment variables from a specific file instead of `.env`.
 
 Examples:
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@anthropic-ai/sdk": "latest",
     "better-sqlite3": "latest",
     "commander": "latest",
+    "dotenv": "^17.3.1",
     "node-cron": "latest",
     "nodemailer": "latest",
     "openai": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       commander:
         specifier: latest
         version: 14.0.3
+      dotenv:
+        specifier: ^17.3.1
+        version: 17.3.1
       node-cron:
         specifier: latest
         version: 4.2.1
@@ -682,6 +685,10 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dotenv@17.3.1:
+    resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
+    engines: {node: '>=12'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -1783,6 +1790,8 @@ snapshots:
   deep-is@0.1.4: {}
 
   detect-libc@2.1.2: {}
+
+  dotenv@17.3.1: {}
 
   end-of-stream@1.4.5:
     dependencies:

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
-import { copyFile, constants } from 'node:fs';
+import { copyFile, constants, existsSync } from 'node:fs';
 import { access } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { config as dotenvConfig } from 'dotenv';
 import { Command, InvalidArgumentError } from 'commander';
 import type { PromptCanaryConfig, RunResult } from '../types/index.js';
 import { VERSION } from '../index.js';
@@ -32,12 +33,30 @@ const ansi = {
 const here = fileURLToPath(new URL('.', import.meta.url));
 const templatePath = resolve(here, '../../examples/basic.yaml');
 
+function loadEnvironment(envFile?: string): void {
+  if (envFile) {
+    const envPath = resolve(process.cwd(), envFile);
+    if (!existsSync(envPath)) {
+      printFailure(`Env file not found: ${envPath}`);
+      process.exitCode = 1;
+      return;
+    }
+    dotenvConfig({ path: envPath, quiet: true });
+  } else {
+    const defaultEnvPath = resolve(process.cwd(), '.env');
+    if (existsSync(defaultEnvPath)) {
+      dotenvConfig({ path: defaultEnvPath, quiet: true });
+    }
+  }
+}
+
 const program = new Command();
 
 program
   .name('promptcanary')
   .description('Uptime monitoring for AI behavior')
-  .version(VERSION);
+  .version(VERSION)
+  .option('--dotenv <path>', 'Path to .env file (defaults to .env in current directory)');
 
 program
   .command('init')
@@ -66,7 +85,7 @@ program
 
     printSuccess(`Created promptcanary.yaml at ${targetPath}`);
     printInfo('Next steps:');
-    printInfo('1. Set OPENAI_API_KEY (and other provider keys) in your environment');
+    printInfo('1. Add your API keys to a .env file or export them in your shell');
     printInfo('2. Edit promptcanary.yaml with your prompts and expectations');
     printInfo('3. Run: promptcanary validate promptcanary.yaml');
     printInfo('4. Run: promptcanary run promptcanary.yaml');
@@ -94,6 +113,8 @@ program
   .option('--json', 'Output machine-readable JSON results', false)
   .option('--verbose', 'Show verbose output', false)
   .action(async (file: string, options: { json: boolean; verbose: boolean }) => {
+    loadEnvironment(program.opts<{ dotenv?: string }>().dotenv);
+    if (process.exitCode === 1) return;
     let storage: Storage | undefined;
     try {
       const config = loadConfig(file);
@@ -134,6 +155,8 @@ program
   .command('monitor <file>')
   .description('Start continuous monitoring from a config schedule')
   .action((file: string) => {
+    loadEnvironment(program.opts<{ dotenv?: string }>().dotenv);
+    if (process.exitCode === 1) return;
     let stop: (() => void) | undefined;
     try {
       const config = loadConfig(file);
@@ -148,7 +171,9 @@ program
           printInfo('Monitoring run started');
         },
         onRunComplete: (passed, failed) => {
-          printInfo(`Monitoring run complete. Passed: ${String(passed)}, Failed: ${String(failed)}`);
+          printInfo(
+            `Monitoring run complete. Passed: ${String(passed)}, Failed: ${String(failed)}`,
+          );
         },
         onError: (error) => {
           printFailure(`Monitoring run error: ${error.message}`);
@@ -259,7 +284,10 @@ async function applyComparisons(
 
     // Skip comparison for results that already failed at the provider level
     // (e.g., missing API key, timeout, rate limit)
-    if (result.response.latency_ms === 0 && result.response.content.startsWith('Provider execution failed:')) {
+    if (
+      result.response.latency_ms === 0 &&
+      result.response.content.startsWith('Provider execution failed:')
+    ) {
       storage.saveRun(result.test_name, testCase.prompt, result);
       continue;
     }
@@ -296,12 +324,7 @@ function printRunTable(results: RunResult[]): void {
     const statusText = result.comparison.passed
       ? `${ansi.green}PASS${ansi.reset}`
       : `${ansi.red}FAIL${ansi.reset}`;
-    return [
-      result.test_name,
-      result.provider,
-      statusText,
-      truncate(result.comparison.details, 80),
-    ];
+    return [result.test_name, result.provider, statusText, truncate(result.comparison.details, 80)];
   });
 
   printTable(headers, dataRows);
@@ -338,9 +361,7 @@ function printTable(headers: string[], rows: string[][]): void {
   printInfo(dividerLine);
 
   for (const row of rows) {
-    const line = row
-      .map((cell, idx) => pad(cell, widths[idx]))
-      .join('  ');
+    const line = row.map((cell, idx) => pad(cell, widths[idx])).join('  ');
     printInfo(line);
   }
 }


### PR DESCRIPTION
## Summary
- Auto-loads `.env` from cwd on `run` and `monitor` commands via dotenv
- Adds `--dotenv <path>` flag for loading env files from custom locations (e.g. outside repo for security)
- Ships `.env.example` template showing required variables
- Adds "API Keys" section to README covering local dev, shell profile, CI/CD, and production environments
- Updates `.gitignore` to exclude `.env` but allow `.env.example`

Closes: N/A (new feature from production readiness review)