### PR TITLE
fix: treat embedding failures as warnings instead of test failures

### DIFF
--- a/src/core/comparator/index.ts
+++ b/src/core/comparator/index.ts
@@ -62,11 +62,11 @@ export async function compareResponse(options: CompareOptions): Promise<Comparis
       });
     } catch (error) {
       assertions.push({
-        type: 'semantic_similarity',
-        passed: false,
+        type: 'embedding_error',
+        passed: true,
         expected: 'embedding comparison',
-        actual: 'error',
-        details: `Embedding error: ${error instanceof Error ? error.message : String(error)}`,
+        actual: 'skipped',
+        details: `Embedding unavailable (warning): ${error instanceof Error ? error.message : String(error)}`,
       });
     }
   }
@@ -77,16 +77,16 @@ export async function compareResponse(options: CompareOptions): Promise<Comparis
     assertions.push(driftResult);
   }
 
-  // Determine overall result
   const failedAssertions = assertions.filter((a) => !a.passed);
-  const severity = determineSeverity(failedAssertions, semanticScore);
+  const hasEmbeddingError = assertions.some((a) => a.type === 'embedding_error');
+  const severity = determineSeverity(failedAssertions, semanticScore, hasEmbeddingError);
 
   return {
     passed: failedAssertions.length === 0,
     severity,
     assertions,
     semantic_score: semanticScore,
-    details: buildDetails(failedAssertions),
+    details: buildDetails(failedAssertions, hasEmbeddingError),
   };
 }
 
@@ -119,24 +119,28 @@ function detectDrift(currentScore: number, historicalScores: number[]): Assertio
 function determineSeverity(
   failedAssertions: AssertionResult[],
   semanticScore?: number,
+  hasEmbeddingError = false,
 ): 'pass' | 'warning' | 'critical' {
-  if (failedAssertions.length === 0) return 'pass';
+  if (failedAssertions.length === 0) {
+    return hasEmbeddingError ? 'warning' : 'pass';
+  }
 
-  // Critical: structural assertion failures or very low semantic score
   const hasStructuralFailure = failedAssertions.some(
     (a) => a.type !== 'semantic_similarity' && a.type !== 'drift_detection',
   );
   if (hasStructuralFailure) return 'critical';
 
-  // Critical: semantic score below 0.5
   if (semanticScore !== undefined && semanticScore < 0.5) return 'critical';
 
-  // Warning: only semantic/drift failures
   return 'warning';
 }
 
-function buildDetails(failedAssertions: AssertionResult[]): string {
-  if (failedAssertions.length === 0) return 'All checks passed';
+function buildDetails(failedAssertions: AssertionResult[], hasEmbeddingError = false): string {
+  if (failedAssertions.length === 0) {
+    return hasEmbeddingError
+      ? 'All checks passed (embedding service unavailable)'
+      : 'All checks passed';
+  }
 
   return failedAssertions
     .map((a) => `[${a.type}] ${a.details ?? `Expected ${a.expected}, got ${a.actual}`}`)

--- a/tests/core/comparator/index.test.ts
+++ b/tests/core/comparator/index.test.ts
@@ -72,7 +72,7 @@ describe('compareResponse', () => {
     expect(result.assertions.some((a) => a.type === 'semantic_similarity')).toBe(false);
   });
 
-  it('handles embedding errors gracefully', async () => {
+  it('treats embedding errors as warnings, not failures', async () => {
     const failingFetcher: EmbeddingFetcher = {
       fetchEmbedding(): Promise<number[]> {
         return Promise.reject(new Error('API error'));
@@ -90,10 +90,39 @@ describe('compareResponse', () => {
       embeddingFetcher: failingFetcher,
     });
 
-    expect(result.passed).toBe(false);
-    const semanticAssertion = result.assertions.find((a) => a.type === 'semantic_similarity');
-    expect(semanticAssertion?.passed).toBe(false);
-    expect(semanticAssertion?.details).toContain('API error');
+    expect(result.passed).toBe(true);
+    expect(result.severity).toBe('warning');
+    const embeddingAssertion = result.assertions.find((a) => a.type === 'embedding_error');
+    expect(embeddingAssertion?.passed).toBe(true);
+    expect(embeddingAssertion?.details).toContain('API error');
+  });
+
+  it('preserves structural results when embedding fails', async () => {
+    const failingFetcher: EmbeddingFetcher = {
+      fetchEmbedding(): Promise<number[]> {
+        return Promise.reject(new Error('service down'));
+      },
+    };
+
+    const result = await compareResponse({
+      response: '- Hello World\n- Another item',
+      expectations: {
+        must_contain: ['hello'],
+        format: 'bullet_points',
+        semantic_similarity: {
+          baseline: 'baseline',
+          threshold: 0.8,
+        },
+      },
+      embeddingFetcher: failingFetcher,
+    });
+
+    expect(result.passed).toBe(true);
+    expect(result.severity).toBe('warning');
+
+    const structuralAssertions = result.assertions.filter((a) => a.type !== 'embedding_error');
+    expect(structuralAssertions.every((a) => a.passed)).toBe(true);
+    expect(result.assertions.some((a) => a.type === 'embedding_error')).toBe(true);
   });
 
   it('runs drift detection with historical scores', async () => {


### PR DESCRIPTION
## Summary
- Embedding API errors now produce a `passed: true` assertion with type `embedding_error` instead of `passed: false` with type `semantic_similarity`
- Overall severity is set to `warning` (not `pass` or `critical`) so users can distinguish "prompt drifted" from "embedding service down"
- Structural assertion results are fully independent — they pass/fail on their own merits regardless of embedding availability
- Updated existing test and added new test verifying structural preservation

Closes #35