### PR TITLE
feat: preserve error type and rate limit info in runner

### DIFF
--- a/src/core/runner/index.ts
+++ b/src/core/runner/index.ts
@@ -1,11 +1,13 @@
 import { randomUUID } from 'node:crypto';
 import type {
   ComparisonResult,
+  ErrorType,
   LLMResponse,
   PromptCanaryConfig,
   ProviderConfig,
   RunResult,
 } from '../../types/index.js';
+import { ProviderError, RateLimitError, TimeoutError } from '../../types/index.js';
 import { createProvider } from './providers/base.js';
 
 export interface RunTestsOptions {
@@ -22,7 +24,13 @@ export async function runTests(options: RunTestsOptions): Promise<RunResult[]> {
     const providerRuns = providerNames.map((providerName) => {
       const providerConfig = options.config.config.providers.find((p) => p.name === providerName);
 
-      return runProviderTest(testCase.name, testCase.prompt, providerName, providerConfig, options.onProgress);
+      return runProviderTest(
+        testCase.name,
+        testCase.prompt,
+        providerName,
+        providerConfig,
+        options.onProgress,
+      );
     });
 
     const settled = await Promise.allSettled(providerRuns);
@@ -108,7 +116,25 @@ function pendingComparison(): ComparisonResult {
   };
 }
 
+function classifyError(error: unknown): { error_type: ErrorType; retry_after_ms?: number } {
+  if (error instanceof RateLimitError) {
+    return { error_type: 'rate_limit', retry_after_ms: error.retry_after_ms };
+  }
+  if (error instanceof TimeoutError) {
+    return { error_type: 'timeout' };
+  }
+  if (error instanceof ProviderError) {
+    const msg = error.message.toLowerCase();
+    if (msg.includes('auth') || msg.includes('api key') || msg.includes('401')) {
+      return { error_type: 'auth' };
+    }
+    return { error_type: 'provider' };
+  }
+  return { error_type: 'unknown' };
+}
+
 function errorResponse(provider: string, model: string, error: unknown): LLMResponse {
+  const { error_type, retry_after_ms } = classifyError(error);
   return {
     content: `Provider execution failed: ${getErrorMessage(error)}`,
     model,
@@ -119,6 +145,8 @@ function errorResponse(provider: string, model: string, error: unknown): LLMResp
       completion: 0,
     },
     timestamp: new Date(),
+    error_type,
+    retry_after_ms,
   };
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,6 +17,8 @@ export type AlertConfig = z.infer<typeof AlertConfigSchema>;
 export type PromptCanaryConfig = z.infer<typeof PromptCanaryConfigSchema>;
 
 // Runtime types (not schema-derived)
+export type ErrorType = 'rate_limit' | 'timeout' | 'auth' | 'provider' | 'unknown';
+
 export interface LLMResponse {
   content: string;
   model: string;
@@ -27,6 +29,8 @@ export interface LLMResponse {
     completion: number;
   };
   timestamp: Date;
+  error_type?: ErrorType;
+  retry_after_ms?: number;
 }
 
 export interface RunResult {

--- a/tests/core/runner/index.test.ts
+++ b/tests/core/runner/index.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { runTests } from '../../../src/core/runner/index.js';
 import { registerProvider, type LLMProvider } from '../../../src/core/runner/providers/base.js';
 import type { LLMResponse, PromptCanaryConfig } from '../../../src/types/index.js';
+import { RateLimitError, TimeoutError, ProviderError } from '../../../src/types/index.js';
 
 function mockResponse(provider: string, model: string, content: string): LLMResponse {
   return {
@@ -84,8 +85,12 @@ describe('runTests', () => {
   it('uses provider overrides when specified on test cases', async () => {
     const providerAName = `provider-override-a-${randomUUID()}`;
     const providerBName = `provider-override-b-${randomUUID()}`;
-    const providerAExecute = vi.fn(() => Promise.resolve(mockResponse(providerAName, 'model-a', 'a')));
-    const providerBExecute = vi.fn(() => Promise.resolve(mockResponse(providerBName, 'model-b', 'b')));
+    const providerAExecute = vi.fn(() =>
+      Promise.resolve(mockResponse(providerAName, 'model-a', 'a')),
+    );
+    const providerBExecute = vi.fn(() =>
+      Promise.resolve(mockResponse(providerBName, 'model-b', 'b')),
+    );
 
     const providerA: LLMProvider = {
       name: providerAName,
@@ -126,7 +131,9 @@ describe('runTests', () => {
   it('isolates provider errors without blocking other providers', async () => {
     const providerOkName = `provider-ok-${randomUUID()}`;
     const providerFailName = `provider-fail-${randomUUID()}`;
-    const providerOkExecute = vi.fn(() => Promise.resolve(mockResponse(providerOkName, 'model-ok', 'ok')));
+    const providerOkExecute = vi.fn(() =>
+      Promise.resolve(mockResponse(providerOkName, 'model-ok', 'ok')),
+    );
     const providerFailExecute = vi.fn(() => Promise.reject(new Error('boom')));
 
     const providerOk: LLMProvider = {
@@ -147,7 +154,12 @@ describe('runTests', () => {
       config: {
         providers: [
           { name: providerOkName, model: 'model-ok', api_key_env: 'KEY_OK', timeout_ms: 1000 },
-          { name: providerFailName, model: 'model-fail', api_key_env: 'KEY_FAIL', timeout_ms: 1000 },
+          {
+            name: providerFailName,
+            model: 'model-fail',
+            api_key_env: 'KEY_FAIL',
+            timeout_ms: 1000,
+          },
         ],
       },
       tests: [{ name: 'error-isolation', prompt: 'hello', expect: {} }],
@@ -161,5 +173,64 @@ describe('runTests', () => {
     expect(okResult?.comparison.passed).toBe(true);
     expect(failResult?.comparison.passed).toBe(false);
     expect(failResult?.response.content).toContain('Provider execution failed');
+  });
+
+  it('preserves rate limit error type and retry_after_ms', async () => {
+    const providerName = `provider-rl-${randomUUID()}`;
+    registerProvider(providerName, {
+      name: providerName,
+      execute: () => Promise.reject(new RateLimitError(providerName, 5000)),
+    });
+
+    const config: PromptCanaryConfig = {
+      version: '1',
+      config: {
+        providers: [{ name: providerName, model: 'model', api_key_env: 'K', timeout_ms: 1000 }],
+      },
+      tests: [{ name: 'rl-test', prompt: 'hello', expect: {} }],
+    };
+
+    const results = await runTests({ config });
+    expect(results[0].response.error_type).toBe('rate_limit');
+    expect(results[0].response.retry_after_ms).toBe(5000);
+  });
+
+  it('preserves timeout error type', async () => {
+    const providerName = `provider-to-${randomUUID()}`;
+    registerProvider(providerName, {
+      name: providerName,
+      execute: () => Promise.reject(new TimeoutError(providerName, 30000)),
+    });
+
+    const config: PromptCanaryConfig = {
+      version: '1',
+      config: {
+        providers: [{ name: providerName, model: 'model', api_key_env: 'K', timeout_ms: 1000 }],
+      },
+      tests: [{ name: 'to-test', prompt: 'hello', expect: {} }],
+    };
+
+    const results = await runTests({ config });
+    expect(results[0].response.error_type).toBe('timeout');
+    expect(results[0].response.retry_after_ms).toBeUndefined();
+  });
+
+  it('classifies auth errors from ProviderError', async () => {
+    const providerName = `provider-auth-${randomUUID()}`;
+    registerProvider(providerName, {
+      name: providerName,
+      execute: () => Promise.reject(new ProviderError('Invalid API key', providerName)),
+    });
+
+    const config: PromptCanaryConfig = {
+      version: '1',
+      config: {
+        providers: [{ name: providerName, model: 'model', api_key_env: 'K', timeout_ms: 1000 }],
+      },
+      tests: [{ name: 'auth-test', prompt: 'hello', expect: {} }],
+    };
+
+    const results = await runTests({ config });
+    expect(results[0].response.error_type).toBe('auth');
   });
 });


### PR DESCRIPTION
## Summary
- Adds `ErrorType` union (`rate_limit | timeout | auth | provider | unknown`) and optional `error_type` / `retry_after_ms` fields to `LLMResponse`
- Runner's `errorResponse()` now classifies errors using `classifyError()` which detects `RateLimitError`, `TimeoutError`, auth-related `ProviderError`, and generic errors
- Enables scheduler to implement intelligent backoff based on error type
- 3 new tests: rate limit with retry_after_ms, timeout classification, auth error classification

Closes #36