### PR TITLE
fix: remove email alert type from schema until implemented

### DIFF
--- a/src/core/alerting/index.ts
+++ b/src/core/alerting/index.ts
@@ -16,9 +16,6 @@ export function createAlertChannels(configs: AlertConfig[]): AlertChannel[] {
         return new SlackAlertChannel(config.webhook_url_env);
       case 'webhook':
         return new WebhookAlertChannel(config.url, config.headers);
-      case 'email':
-        // Email alerting is a post-MVP feature
-        throw new Error('Email alerting is not yet implemented');
       default:
         throw new Error(`Unknown alert channel type`);
     }
@@ -68,9 +65,7 @@ export async function dispatchAlerts(options: DispatchAlertsOptions): Promise<vo
         if (recentlySent) continue;
       }
 
-      alertPromises.push(
-        sendAlert(channel, alert, storage, result.run_id),
-      );
+      alertPromises.push(sendAlert(channel, alert, storage, result.run_id));
     }
   }
 
@@ -85,7 +80,12 @@ async function sendAlert(
 ): Promise<void> {
   try {
     await channel.send(alert);
-    storage?.saveAlert(runId, channel.type, { ...alert, timestamp: alert.timestamp.toISOString() }, true);
+    storage?.saveAlert(
+      runId,
+      channel.type,
+      { ...alert, timestamp: alert.timestamp.toISOString() },
+      true,
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     storage?.saveAlert(runId, channel.type, { error: message }, false);

--- a/src/schema/test-case.ts
+++ b/src/schema/test-case.ts
@@ -113,15 +113,6 @@ export const AlertConfigSchema = z.discriminatedUnion('type', [
       .describe('Environment variable containing Slack webhook URL'),
   }),
   z.object({
-    type: z.literal('email'),
-    smtp_host_env: z.string().min(1).describe('SMTP host env var'),
-    smtp_port: z.number().int().positive().default(587).describe('SMTP port'),
-    smtp_user_env: z.string().min(1).describe('SMTP username env var'),
-    smtp_pass_env: z.string().min(1).describe('SMTP password env var'),
-    from: z.string().min(1).describe('From email address'),
-    to: z.array(z.string().min(1)).min(1).describe('Recipient email addresses'),
-  }),
-  z.object({
     type: z.literal('webhook'),
     url: z
       .string()

--- a/tests/schema/test-case.test.ts
+++ b/tests/schema/test-case.test.ts
@@ -178,17 +178,18 @@ describe('AlertConfigSchema', () => {
     expect(result.type).toBe('webhook');
   });
 
-  it('validates an email alert', () => {
-    const result = AlertConfigSchema.parse({
-      type: 'email',
-      smtp_host_env: 'SMTP_HOST',
-      smtp_port: 587,
-      smtp_user_env: 'SMTP_USER',
-      smtp_pass_env: 'SMTP_PASS',
-      from: 'alerts@example.com',
-      to: ['dev@example.com'],
-    });
-    expect(result.type).toBe('email');
+  it('rejects email type (not implemented)', () => {
+    expect(() =>
+      AlertConfigSchema.parse({
+        type: 'email',
+        smtp_host_env: 'SMTP_HOST',
+        smtp_port: 587,
+        smtp_user_env: 'SMTP_USER',
+        smtp_pass_env: 'SMTP_PASS',
+        from: 'alerts@example.com',
+        to: ['dev@example.com'],
+      }),
+    ).toThrow();
   });
 
   it('rejects webhook with invalid URL', () => {
@@ -252,8 +253,18 @@ describe('PromptCanaryConfigSchema', () => {
   });
 
   it('rejects invalid version', () => {
-    expect(() =>
-      PromptCanaryConfigSchema.parse({ ...minimalConfig, version: '2' }),
-    ).toThrow();
+    expect(() => PromptCanaryConfigSchema.parse({ ...minimalConfig, version: '2' })).toThrow();
+  });
+});
+
+describe('AlertConfigSchema', () => {
+  it('accepts slack config', () => {
+    const result = AlertConfigSchema.parse({ type: 'slack', webhook_url_env: 'SLACK_URL' });
+    expect(result.type).toBe('slack');
+  });
+
+  it('accepts webhook config', () => {
+    const result = AlertConfigSchema.parse({ type: 'webhook', url: 'https://example.com/hook' });
+    expect(result.type).toBe('webhook');
   });
 });


### PR DESCRIPTION
## Summary
- Removes `email` variant from `AlertConfigSchema` discriminated union — configs with `type: email` are now rejected at validation time with a clear Zod error instead of crashing at runtime
- Removes dead `case 'email'` branch from `createAlertChannels()`
- Updates existing test from "validates email" to "rejects email" and adds AlertConfigSchema-specific tests

Closes #39