### PR TITLE
feat: add retry logic to Slack alerting

### DIFF
--- a/src/core/alerting/slack.ts
+++ b/src/core/alerting/slack.ts
@@ -3,13 +3,17 @@ import type { AlertPayload, AlertChannel } from '../../types/index.js';
 export class SlackAlertChannel implements AlertChannel {
   type = 'slack' as const;
   private webhookUrl: string;
+  private maxRetries: number;
 
-  constructor(webhookUrlEnv: string) {
+  constructor(webhookUrlEnv: string, maxRetries = 2) {
     const url = process.env[webhookUrlEnv];
     if (!url) {
-      throw new Error(`Missing Slack webhook URL: environment variable ${webhookUrlEnv} is not set`);
+      throw new Error(
+        `Missing Slack webhook URL: environment variable ${webhookUrlEnv} is not set`,
+      );
     }
     this.webhookUrl = url;
+    this.maxRetries = maxRetries;
   }
 
   async send(alert: AlertPayload): Promise<void> {
@@ -58,15 +62,29 @@ export class SlackAlertChannel implements AlertChannel {
       ],
     };
 
-    const response = await fetch(this.webhookUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    });
+    let lastError: Error | undefined;
 
-    if (!response.ok) {
-      const text = await response.text();
-      throw new Error(`Slack webhook failed (${String(response.status)}): ${text}`);
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      try {
+        const response = await fetch(this.webhookUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+
+        if (response.ok) return;
+
+        const text = await response.text();
+        lastError = new Error(`Slack webhook failed (${String(response.status)}): ${text}`);
+      } catch (err) {
+        lastError = err instanceof Error ? err : new Error(String(err));
+      }
+
+      if (attempt < this.maxRetries) {
+        await new Promise((resolve) => setTimeout(resolve, 1000 * 2 ** attempt));
+      }
     }
+
+    throw lastError ?? new Error('Slack webhook failed after retries');
   }
 }

--- a/tests/core/alerting/slack.test.ts
+++ b/tests/core/alerting/slack.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SlackAlertChannel } from '../../../src/core/alerting/slack.js';
+import type { AlertPayload } from '../../../src/types/index.js';
+
+const mockAlert: AlertPayload = {
+  test_name: 'Test Case 1',
+  provider: 'openai',
+  model: 'gpt-4o',
+  failure_type: 'assertion',
+  details: 'must_contain check failed',
+  severity: 'critical',
+  timestamp: new Date('2025-01-01T00:00:00Z'),
+  run_id: 'run-123',
+};
+
+describe('SlackAlertChannel', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it('throws when env var is not set', () => {
+    expect(() => new SlackAlertChannel('MISSING_SLACK_VAR')).toThrow('Missing Slack webhook URL');
+  });
+
+  it('sends POST request with Slack block payload', async () => {
+    vi.stubEnv('TEST_SLACK_URL', 'https://hooks.slack.com/test');
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('ok', { status: 200 }));
+
+    const channel = new SlackAlertChannel('TEST_SLACK_URL');
+    await channel.send(mockAlert);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://hooks.slack.com/test');
+    expect(options?.method).toBe('POST');
+
+    const body = JSON.parse(options?.body as string) as { attachments: unknown[] };
+    expect(body.attachments).toHaveLength(1);
+  });
+
+  it('retries on failure', async () => {
+    vi.stubEnv('TEST_SLACK_URL', 'https://hooks.slack.com/test');
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('rate limited', { status: 429 }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    const channel = new SlackAlertChannel('TEST_SLACK_URL', 2);
+    await channel.send(mockAlert);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws after all retries exhausted', async () => {
+    vi.stubEnv('TEST_SLACK_URL', 'https://hooks.slack.com/test');
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('error', { status: 500 }));
+
+    const channel = new SlackAlertChannel('TEST_SLACK_URL', 0);
+    await expect(channel.send(mockAlert)).rejects.toThrow('Slack webhook failed');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds retry with exponential backoff to `SlackAlertChannel.send()` (default 2 retries, matching webhook pattern)
- Configurable `maxRetries` constructor parameter
- 4 new unit tests: env var validation, payload structure, retry on failure, exhausted retries

Closes #40