### PR TITLE
feat: persist embedding cache across scheduler runs

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -119,7 +119,7 @@ program
     try {
       const config = loadConfig(file);
       storage = new Storage();
-      const embeddingCache = new EmbeddingCache();
+      const embeddingCache = new EmbeddingCache(storage);
       const embeddingFetcher = createEmbeddingFetcher(config);
 
       const runResults = await runTests({

--- a/src/core/comparator/embedding.ts
+++ b/src/core/comparator/embedding.ts
@@ -33,23 +33,45 @@ export function contentHash(text: string): string {
   return createHash('sha256').update(text).digest('hex');
 }
 
-/**
- * Embedding cache — stores embeddings in memory with content hash keys.
- * Can be backed by SQLite storage for persistence.
- */
+export interface EmbeddingCacheBacking {
+  getCachedEmbedding(hash: string): number[] | undefined;
+  cacheEmbedding(hash: string, embedding: number[], model: string): void;
+}
+
 export class EmbeddingCache {
   private cache = new Map<string, number[]>();
+  private backing?: EmbeddingCacheBacking;
+  private model: string;
+
+  constructor(backing?: EmbeddingCacheBacking, model = 'text-embedding-3-small') {
+    this.backing = backing;
+    this.model = model;
+  }
 
   get(text: string): number[] | undefined {
-    return this.cache.get(contentHash(text));
+    const hash = contentHash(text);
+    const memCached = this.cache.get(hash);
+    if (memCached) return memCached;
+
+    if (this.backing) {
+      const persisted = this.backing.getCachedEmbedding(hash);
+      if (persisted) {
+        this.cache.set(hash, persisted);
+        return persisted;
+      }
+    }
+
+    return undefined;
   }
 
   set(text: string, embedding: number[]): void {
-    this.cache.set(contentHash(text), embedding);
+    const hash = contentHash(text);
+    this.cache.set(hash, embedding);
+    this.backing?.cacheEmbedding(hash, embedding, this.model);
   }
 
   has(text: string): boolean {
-    return this.cache.has(contentHash(text));
+    return this.get(text) !== undefined;
   }
 
   clear(): void {

--- a/src/core/scheduler/index.ts
+++ b/src/core/scheduler/index.ts
@@ -32,7 +32,7 @@ export function startScheduler(options: SchedulerOptions): { stop: () => void } 
   }
 
   const storage = new Storage(dbPath);
-  const embeddingCache = new EmbeddingCache();
+  const embeddingCache = new EmbeddingCache(storage);
 
   let isRunning = false;
 

--- a/tests/core/comparator/embedding.test.ts
+++ b/tests/core/comparator/embedding.test.ts
@@ -6,7 +6,10 @@ import {
   computeSemanticSimilarity,
   OpenAIEmbeddingFetcher,
 } from '../../../src/core/comparator/embedding.js';
-import type { EmbeddingFetcher } from '../../../src/core/comparator/embedding.js';
+import type {
+  EmbeddingFetcher,
+  EmbeddingCacheBacking,
+} from '../../../src/core/comparator/embedding.js';
 
 describe('cosineSimilarity', () => {
   it('returns 1 for identical vectors', () => {
@@ -87,6 +90,46 @@ describe('EmbeddingCache', () => {
     cache.set('b', [2]);
     cache.clear();
     expect(cache.size).toBe(0);
+  });
+
+  it('falls back to backing store on memory miss', () => {
+    const backing: EmbeddingCacheBacking = {
+      getCachedEmbedding: vi.fn().mockReturnValue([4, 5, 6]),
+      cacheEmbedding: vi.fn(),
+    };
+
+    const cache = new EmbeddingCache(backing);
+    const result = cache.get('persisted-text');
+    expect(result).toEqual([4, 5, 6]);
+    expect(backing.getCachedEmbedding).toHaveBeenCalledOnce();
+  });
+
+  it('writes through to backing store on set', () => {
+    const backing: EmbeddingCacheBacking = {
+      getCachedEmbedding: vi.fn(),
+      cacheEmbedding: vi.fn(),
+    };
+
+    const cache = new EmbeddingCache(backing, 'test-model');
+    cache.set('new-text', [7, 8, 9]);
+    expect(backing.cacheEmbedding).toHaveBeenCalledOnce();
+    expect(backing.cacheEmbedding).toHaveBeenCalledWith(
+      contentHash('new-text'),
+      [7, 8, 9],
+      'test-model',
+    );
+  });
+
+  it('promotes backing store hit to memory', () => {
+    const backing: EmbeddingCacheBacking = {
+      getCachedEmbedding: vi.fn().mockReturnValueOnce([1, 2, 3]).mockReturnValue(undefined),
+      cacheEmbedding: vi.fn(),
+    };
+
+    const cache = new EmbeddingCache(backing);
+    cache.get('text');
+    cache.get('text');
+    expect(backing.getCachedEmbedding).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- `EmbeddingCache` now accepts optional `EmbeddingCacheBacking` (interface satisfied by `Storage`)
- Memory miss falls through to SQLite; hits are promoted to memory for fast subsequent access
- `set()` writes through to both memory and SQLite
- Scheduler and CLI both pass `Storage` as backing, saving API quota on repeated baseline embeddings
- 3 new tests: backing store fallback, write-through, memory promotion

Closes #41