### PR TITLE
feat: warn when embedding provider init fails in scheduler

### DIFF
--- a/src/core/scheduler/index.ts
+++ b/src/core/scheduler/index.ts
@@ -13,6 +13,7 @@ export interface SchedulerOptions {
   onRunStart?: () => void;
   onRunComplete?: (passed: number, failed: number) => void;
   onError?: (error: Error) => void;
+  onWarning?: (message: string) => void;
 }
 
 /**
@@ -20,7 +21,7 @@ export interface SchedulerOptions {
  * Returns a stop function to gracefully shut down.
  */
 export function startScheduler(options: SchedulerOptions): { stop: () => void } {
-  const { config, dbPath, onRunStart, onRunComplete, onError } = options;
+  const { config, dbPath, onRunStart, onRunComplete, onError, onWarning } = options;
   const schedule = config.config.schedule;
 
   if (!schedule) {
@@ -39,7 +40,16 @@ export function startScheduler(options: SchedulerOptions): { stop: () => void } 
   const task = cron.schedule(schedule, () => {
     // Prevent overlapping runs
     if (isRunning) return;
-    void executeRun(config, storage, embeddingCache, isRunning, onRunStart, onRunComplete, onError)
+    void executeRun(
+      config,
+      storage,
+      embeddingCache,
+      isRunning,
+      onRunStart,
+      onRunComplete,
+      onError,
+      onWarning,
+    )
       .then(() => {
         isRunning = false;
       })
@@ -74,11 +84,11 @@ export async function executeRun(
   onRunStart?: () => void,
   onRunComplete?: (passed: number, failed: number) => void,
   onError?: (error: Error) => void,
+  onWarning?: (message: string) => void,
 ): Promise<{ passed: number; failed: number }> {
   onRunStart?.();
 
   try {
-    // Create embedding fetcher if configured
     let embeddingFetcher: EmbeddingFetcher | undefined;
     const embeddingConfig = config.config.embedding_provider;
     if (embeddingConfig) {
@@ -87,8 +97,11 @@ export async function executeRun(
           embeddingConfig.api_key_env,
           embeddingConfig.model,
         );
-      } catch {
-        // Embedding provider not configured — skip semantic checks
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        onWarning?.(
+          `Embedding provider failed to initialize: ${reason}. Semantic similarity checks will be skipped.`,
+        );
       }
     }
 

--- a/tests/core/scheduler/index.test.ts
+++ b/tests/core/scheduler/index.test.ts
@@ -56,4 +56,28 @@ describe('executeRun', () => {
 
     expect(shouldSkipComparison).toBe(true);
   });
+
+  it('calls onWarning when embedding provider fails to initialize', async () => {
+    const config: PromptCanaryConfig = {
+      ...minimalConfig,
+      config: {
+        ...minimalConfig.config,
+        embedding_provider: {
+          api_key_env: 'NONEXISTENT_EMBEDDING_KEY_FOR_TEST',
+          model: 'text-embedding-3-small',
+        },
+      },
+    };
+
+    const storage = new Storage(':memory:');
+    const cache = new EmbeddingCache();
+    const onWarning = vi.fn();
+
+    await executeRun(config, storage, cache, false, undefined, undefined, undefined, onWarning);
+
+    expect(onWarning).toHaveBeenCalledOnce();
+    expect(onWarning.mock.calls[0][0]).toContain('Embedding provider failed to initialize');
+    expect(onWarning.mock.calls[0][0]).toContain('NONEXISTENT_EMBEDDING_KEY_FOR_TEST');
+    storage.close();
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `onWarning` callback to `SchedulerOptions` and `executeRun()`
- Embedding init failure now calls `onWarning()` with the reason instead of silently swallowing
- Users can distinguish "no embedding_provider configured" from "API key missing"
- 1 new test verifying warning callback is called with descriptive message

Closes #42