### PR TITLE
Fix GitHub Pages 404: add VitePress base path

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -4,7 +4,9 @@ export default defineConfig({
   title: 'PromptCanary',
   description: 'Uptime monitoring for AI behavior. Catch model drift before your users do.',
 
-  head: [['link', { rel: 'icon', type: 'image/svg+xml', href: '/logo.svg' }]],
+  base: '/promptcanary/',
+
+  head: [['link', { rel: 'icon', type: 'image/svg+xml', href: '/promptcanary/logo.svg' }]],
 
   themeConfig: {
     logo: '/logo.svg',


### PR DESCRIPTION
## Summary

- Adds `base: '/promptcanary/'` to VitePress config so assets resolve correctly on GitHub Pages project sites
- Updates favicon `href` to include the base prefix

## Problem

GitHub Pages serves project repos at `https://<user>.github.io/<repo>/`, but VitePress defaults to root-relative paths (`/assets/...`). This caused a 404 on the deployed docs site.

## Verification

- `pnpm docs:build` succeeds
- Built HTML correctly references `/promptcanary/assets/...` paths
- All 167 tests pass, typecheck + lint clean

Closes #61