### PR TITLE
feat: add standalone semanticSimilarity() function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export type {
   TestPromptOptions,
   TestPromptResult,
   ChatMessage,
+  SemanticSimilarityOptions,
 } from './types/index.js';
 
 export { ProviderError, TimeoutError, RateLimitError, ConfigError } from './types/index.js';
@@ -45,3 +46,4 @@ export { dispatchAlerts, createAlertChannels } from './core/alerting/index.js';
 export { Storage } from './storage/index.js';
 
 export { testPrompt } from './testing/testPrompt.js';
+export { semanticSimilarity } from './testing/semanticSimilarity.js';

--- a/src/testing/semanticSimilarity.ts
+++ b/src/testing/semanticSimilarity.ts
@@ -1,0 +1,32 @@
+import { computeSemanticSimilarity, OpenAIEmbeddingFetcher } from '../core/comparator/embedding.js';
+import type { SemanticSimilarityOptions } from '../types/index.js';
+
+const DEFAULT_MODEL = 'text-embedding-3-small';
+const DEFAULT_API_KEY_ENV = 'OPENAI_API_KEY';
+
+export async function semanticSimilarity(
+  actual: string,
+  expected: string,
+  options?: SemanticSimilarityOptions,
+): Promise<number> {
+  const model = options?.model ?? DEFAULT_MODEL;
+  const apiKeyEnv = DEFAULT_API_KEY_ENV;
+
+  const previousKey = process.env[apiKeyEnv];
+  if (options?.apiKey) {
+    process.env[apiKeyEnv] = options.apiKey;
+  }
+
+  try {
+    const fetcher = new OpenAIEmbeddingFetcher(apiKeyEnv, model);
+    return await computeSemanticSimilarity(actual, expected, fetcher);
+  } finally {
+    if (options?.apiKey) {
+      if (previousKey === undefined) {
+        Reflect.deleteProperty(process.env, apiKeyEnv);
+      } else {
+        process.env[apiKeyEnv] = previousKey;
+      }
+    }
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,6 +45,11 @@ export interface TestPromptResult {
   };
 }
 
+export interface SemanticSimilarityOptions {
+  model?: string;
+  apiKey?: string;
+}
+
 export interface LLMResponse {
   content: string;
   model: string;

--- a/tests/testing/semanticSimilarity.test.ts
+++ b/tests/testing/semanticSimilarity.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockFetchEmbedding = vi.fn();
+const constructorCalls: Array<{ apiKeyEnv: string; model: string }> = [];
+
+vi.mock('../../src/core/comparator/embedding.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/core/comparator/embedding.js')>();
+  return {
+    ...actual,
+    OpenAIEmbeddingFetcher: class MockEmbeddingFetcher {
+      constructor(apiKeyEnv: string, model: string) {
+        if (!process.env[apiKeyEnv]) {
+          throw new Error(`Missing API key: environment variable ${apiKeyEnv} is not set`);
+        }
+        constructorCalls.push({ apiKeyEnv, model });
+      }
+      fetchEmbedding = mockFetchEmbedding;
+    },
+  };
+});
+
+import { semanticSimilarity } from '../../src/testing/semanticSimilarity.js';
+
+const MOCK_EMBEDDING_A = [0.6, 0.8, 0.0];
+const MOCK_EMBEDDING_B = [0.8, 0.6, 0.0];
+
+describe('semanticSimilarity', () => {
+  let originalKey: string | undefined;
+
+  beforeEach(() => {
+    originalKey = process.env['OPENAI_API_KEY'];
+    process.env['OPENAI_API_KEY'] = 'test-key-123';
+    mockFetchEmbedding.mockReset();
+    constructorCalls.length = 0;
+  });
+
+  afterEach(() => {
+    if (originalKey === undefined) {
+      delete process.env['OPENAI_API_KEY'];
+    } else {
+      process.env['OPENAI_API_KEY'] = originalKey;
+    }
+  });
+
+  it('computes cosine similarity between two strings', async () => {
+    mockFetchEmbedding
+      .mockResolvedValueOnce(MOCK_EMBEDDING_A)
+      .mockResolvedValueOnce(MOCK_EMBEDDING_B);
+
+    const score = await semanticSimilarity('text a', 'text b');
+
+    expect(score).toBeCloseTo(0.96, 2);
+    expect(mockFetchEmbedding).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns 1.0 for identical embeddings', async () => {
+    mockFetchEmbedding
+      .mockResolvedValueOnce(MOCK_EMBEDDING_A)
+      .mockResolvedValueOnce(MOCK_EMBEDDING_A);
+
+    const score = await semanticSimilarity('same', 'same');
+
+    expect(score).toBeCloseTo(1.0, 5);
+  });
+
+  it('uses default model text-embedding-3-small', async () => {
+    mockFetchEmbedding
+      .mockResolvedValueOnce(MOCK_EMBEDDING_A)
+      .mockResolvedValueOnce(MOCK_EMBEDDING_B);
+
+    await semanticSimilarity('a', 'b');
+
+    expect(constructorCalls[0].model).toBe('text-embedding-3-small');
+  });
+
+  it('accepts custom model override', async () => {
+    mockFetchEmbedding
+      .mockResolvedValueOnce(MOCK_EMBEDDING_A)
+      .mockResolvedValueOnce(MOCK_EMBEDDING_B);
+
+    await semanticSimilarity('a', 'b', { model: 'text-embedding-3-large' });
+
+    expect(constructorCalls[0].model).toBe('text-embedding-3-large');
+  });
+
+  it('uses explicit apiKey and restores env afterwards', async () => {
+    mockFetchEmbedding
+      .mockResolvedValueOnce(MOCK_EMBEDDING_A)
+      .mockResolvedValueOnce(MOCK_EMBEDDING_B);
+
+    const keyBefore = process.env['OPENAI_API_KEY'];
+    await semanticSimilarity('a', 'b', { apiKey: 'explicit-key' });
+    const keyAfter = process.env['OPENAI_API_KEY'];
+
+    expect(keyAfter).toBe(keyBefore);
+  });
+
+  it('restores env even when fetch fails', async () => {
+    mockFetchEmbedding.mockRejectedValueOnce(new Error('API down'));
+
+    const keyBefore = process.env['OPENAI_API_KEY'];
+    await expect(semanticSimilarity('a', 'b', { apiKey: 'temp-key' })).rejects.toThrow('API down');
+    const keyAfter = process.env['OPENAI_API_KEY'];
+
+    expect(keyAfter).toBe(keyBefore);
+  });
+
+  it('throws when OPENAI_API_KEY is missing and no explicit key given', async () => {
+    delete process.env['OPENAI_API_KEY'];
+
+    await expect(semanticSimilarity('a', 'b')).rejects.toThrow('Missing API key');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `semanticSimilarity(a, b, options?)` function that computes cosine similarity between two strings using OpenAI embeddings
- New type `SemanticSimilarityOptions` for configuring model and API key
- 7 unit tests covering similarity computation, custom options, API key resolution, and error handling
- Exported from package root for direct import: `import { semanticSimilarity } from 'promptcanary'`

Closes #65