### PR TITLE
feat: add assertion helper functions for test suites

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,3 +47,5 @@ export { Storage } from './storage/index.js';
 
 export { testPrompt } from './testing/testPrompt.js';
 export { semanticSimilarity } from './testing/semanticSimilarity.js';
+export { assertions } from './testing/assertions.js';
+export type { AssertionDescriptor, RunAllResult } from './testing/assertions.js';

--- a/src/testing/assertions.ts
+++ b/src/testing/assertions.ts
@@ -1,0 +1,188 @@
+import type { AssertionResult } from '../types/index.js';
+
+function contains(content: string, substring: string): AssertionResult {
+  const passed = content.toLowerCase().includes(substring.toLowerCase());
+  return {
+    type: 'contains',
+    passed,
+    expected: `contains "${substring}"`,
+    actual: passed ? 'found' : 'not found',
+    details: passed ? undefined : `Content does not contain "${substring}"`,
+  };
+}
+
+function notContains(content: string, substring: string): AssertionResult {
+  const found = content.toLowerCase().includes(substring.toLowerCase());
+  return {
+    type: 'not_contains',
+    passed: !found,
+    expected: `does not contain "${substring}"`,
+    actual: found ? 'found' : 'not found',
+    details: found ? `Content contains forbidden substring "${substring}"` : undefined,
+  };
+}
+
+function maxLength(content: string, max: number): AssertionResult {
+  const passed = content.length <= max;
+  return {
+    type: 'max_length',
+    passed,
+    expected: `<= ${String(max)} characters`,
+    actual: `${String(content.length)} characters`,
+    details: passed
+      ? undefined
+      : `Content exceeds max length by ${String(content.length - max)} characters`,
+  };
+}
+
+function minLength(content: string, min: number): AssertionResult {
+  const passed = content.length >= min;
+  return {
+    type: 'min_length',
+    passed,
+    expected: `>= ${String(min)} characters`,
+    actual: `${String(content.length)} characters`,
+    details: passed ? undefined : `Content is ${String(min - content.length)} characters too short`,
+  };
+}
+
+function matchesRegex(content: string, pattern: RegExp | string): AssertionResult {
+  const regex = typeof pattern === 'string' ? new RegExp(pattern) : pattern;
+  const passed = regex.test(content);
+  return {
+    type: 'regex',
+    passed,
+    expected: `matches ${String(regex)}`,
+    actual: passed ? 'matched' : 'no match',
+    details: passed ? undefined : `Content does not match pattern ${String(regex)}`,
+  };
+}
+
+function isJson(content: string): AssertionResult {
+  let passed = false;
+  try {
+    JSON.parse(content);
+    passed = true;
+  } catch {
+    // empty
+  }
+  return {
+    type: 'is_json',
+    passed,
+    expected: 'valid JSON',
+    actual: passed ? 'valid JSON' : 'invalid JSON',
+    details: passed ? undefined : 'Content is not valid JSON',
+  };
+}
+
+/**
+ * Validates content against a shallow JSON schema where each key maps to
+ * an expected `typeof` value (e.g. `{ name: "string", age: "number" }`).
+ */
+function matchesJsonSchema(content: string, schema: Record<string, string>): AssertionResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return {
+      type: 'json_schema',
+      passed: false,
+      expected: 'valid JSON matching schema',
+      actual: 'invalid JSON',
+      details: 'Content is not valid JSON',
+    };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {
+      type: 'json_schema',
+      passed: false,
+      expected: 'JSON object matching schema',
+      actual: Array.isArray(parsed) ? 'array' : typeof parsed,
+      details: 'Content is not a JSON object',
+    };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  const errors: string[] = [];
+
+  for (const [key, expectedType] of Object.entries(schema)) {
+    if (!(key in obj)) {
+      errors.push(`missing key "${key}"`);
+    } else if (typeof obj[key] !== expectedType) {
+      errors.push(`key "${key}" expected ${expectedType}, got ${typeof obj[key]}`);
+    }
+  }
+
+  const passed = errors.length === 0;
+  return {
+    type: 'json_schema',
+    passed,
+    expected: 'matches JSON schema',
+    actual: passed ? 'matches' : errors.join('; '),
+    details: passed ? undefined : errors.join('; '),
+  };
+}
+
+export interface AssertionDescriptor {
+  type:
+    | 'contains'
+    | 'not_contains'
+    | 'max_length'
+    | 'min_length'
+    | 'regex'
+    | 'is_json'
+    | 'json_schema';
+  value: string | number | RegExp | Record<string, string>;
+}
+
+export interface RunAllResult {
+  passed: boolean;
+  results: AssertionResult[];
+}
+
+function runAll(content: string, descriptors: AssertionDescriptor[]): RunAllResult {
+  const results: AssertionResult[] = [];
+
+  for (const descriptor of descriptors) {
+    switch (descriptor.type) {
+      case 'contains':
+        results.push(contains(content, descriptor.value as string));
+        break;
+      case 'not_contains':
+        results.push(notContains(content, descriptor.value as string));
+        break;
+      case 'max_length':
+        results.push(maxLength(content, Number(descriptor.value)));
+        break;
+      case 'min_length':
+        results.push(minLength(content, Number(descriptor.value)));
+        break;
+      case 'regex':
+        results.push(matchesRegex(content, descriptor.value as RegExp | string));
+        break;
+      case 'is_json':
+        results.push(isJson(content));
+        break;
+      case 'json_schema':
+        results.push(matchesJsonSchema(content, descriptor.value as Record<string, string>));
+        break;
+    }
+  }
+
+  return {
+    passed: results.every((r) => r.passed),
+    results,
+  };
+}
+
+export const assertions = {
+  contains,
+  notContains,
+  maxLength,
+  minLength,
+  matchesRegex,
+  isJson,
+  matchesJsonSchema,
+  runAll,
+} as const;

--- a/tests/testing/assertions.test.ts
+++ b/tests/testing/assertions.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest';
+import { assertions } from '../../src/testing/assertions.js';
+import type { AssertionDescriptor } from '../../src/testing/assertions.js';
+
+describe('assertions', () => {
+  describe('contains', () => {
+    it('passes when content contains substring', () => {
+      const result = assertions.contains('Your refund will arrive in 30 days', 'refund');
+      expect(result.passed).toBe(true);
+      expect(result.type).toBe('contains');
+    });
+
+    it('is case-insensitive', () => {
+      const result = assertions.contains('REFUND processed', 'refund');
+      expect(result.passed).toBe(true);
+    });
+
+    it('fails when content does not contain substring', () => {
+      const result = assertions.contains('Your order is confirmed', 'refund');
+      expect(result.passed).toBe(false);
+      expect(result.details).toContain('refund');
+    });
+
+    it('handles empty content', () => {
+      const result = assertions.contains('', 'anything');
+      expect(result.passed).toBe(false);
+    });
+  });
+
+  describe('notContains', () => {
+    it('passes when content does not contain substring', () => {
+      const result = assertions.notContains('Everything is fine', 'error');
+      expect(result.passed).toBe(true);
+      expect(result.type).toBe('not_contains');
+    });
+
+    it('fails when content contains forbidden substring', () => {
+      const result = assertions.notContains('An error occurred', 'error');
+      expect(result.passed).toBe(false);
+      expect(result.details).toContain('forbidden');
+    });
+
+    it('is case-insensitive', () => {
+      const result = assertions.notContains('ERROR occurred', 'error');
+      expect(result.passed).toBe(false);
+    });
+  });
+
+  describe('maxLength', () => {
+    it('passes when content is within limit', () => {
+      const result = assertions.maxLength('short', 500);
+      expect(result.passed).toBe(true);
+      expect(result.type).toBe('max_length');
+    });
+
+    it('passes when content is exactly at limit', () => {
+      const result = assertions.maxLength('abc', 3);
+      expect(result.passed).toBe(true);
+    });
+
+    it('fails when content exceeds limit', () => {
+      const result = assertions.maxLength('this is too long', 5);
+      expect(result.passed).toBe(false);
+      expect(result.details).toContain('exceeds');
+    });
+  });
+
+  describe('minLength', () => {
+    it('passes when content meets minimum', () => {
+      const result = assertions.minLength('sufficient length content', 5);
+      expect(result.passed).toBe(true);
+      expect(result.type).toBe('min_length');
+    });
+
+    it('passes when content is exactly at minimum', () => {
+      const result = assertions.minLength('abc', 3);
+      expect(result.passed).toBe(true);
+    });
+
+    it('fails when content is too short', () => {
+      const result = assertions.minLength('hi', 10);
+      expect(result.passed).toBe(false);
+      expect(result.details).toContain('too short');
+    });
+  });
+
+  describe('matchesRegex', () => {
+    it('passes with RegExp object', () => {
+      const result = assertions.matchesRegex('Delivery in 5 days', /\d+ days/);
+      expect(result.passed).toBe(true);
+      expect(result.type).toBe('regex');
+    });
+
+    it('passes with string pattern', () => {
+      const result = assertions.matchesRegex('Delivery in 5 days', '\\d+ days');
+      expect(result.passed).toBe(true);
+    });
+
+    it('fails when pattern does not match', () => {
+      const result = assertions.matchesRegex('No numbers here', /\d+/);
+      expect(result.passed).toBe(false);
+      expect(result.details).toContain('does not match');
+    });
+  });
+
+  describe('isJson', () => {
+    it('passes for valid JSON object', () => {
+      const result = assertions.isJson('{"name":"test","value":42}');
+      expect(result.passed).toBe(true);
+      expect(result.type).toBe('is_json');
+    });
+
+    it('passes for valid JSON array', () => {
+      const result = assertions.isJson('[1,2,3]');
+      expect(result.passed).toBe(true);
+    });
+
+    it('fails for invalid JSON', () => {
+      const result = assertions.isJson('not json at all');
+      expect(result.passed).toBe(false);
+      expect(result.details).toContain('not valid JSON');
+    });
+
+    it('fails for empty string', () => {
+      const result = assertions.isJson('');
+      expect(result.passed).toBe(false);
+    });
+  });
+
+  describe('matchesJsonSchema', () => {
+    it('passes when all keys match expected types', () => {
+      const result = assertions.matchesJsonSchema('{"name":"Alice","age":30}', {
+        name: 'string',
+        age: 'number',
+      });
+      expect(result.passed).toBe(true);
+      expect(result.type).toBe('json_schema');
+    });
+
+    it('fails when a key is missing', () => {
+      const result = assertions.matchesJsonSchema('{"name":"Alice"}', {
+        name: 'string',
+        age: 'number',
+      });
+      expect(result.passed).toBe(false);
+      expect(result.details).toContain('missing key "age"');
+    });
+
+    it('fails when a key has wrong type', () => {
+      const result = assertions.matchesJsonSchema('{"name":"Alice","age":"thirty"}', {
+        name: 'string',
+        age: 'number',
+      });
+      expect(result.passed).toBe(false);
+      expect(result.details).toContain('expected number, got string');
+    });
+
+    it('fails for invalid JSON', () => {
+      const result = assertions.matchesJsonSchema('not json', { key: 'string' });
+      expect(result.passed).toBe(false);
+      expect(result.details).toContain('not valid JSON');
+    });
+
+    it('fails for JSON array', () => {
+      const result = assertions.matchesJsonSchema('[1,2]', { key: 'string' });
+      expect(result.passed).toBe(false);
+      expect(result.details).toContain('not a JSON object');
+    });
+
+    it('fails for JSON primitive', () => {
+      const result = assertions.matchesJsonSchema('"hello"', { key: 'string' });
+      expect(result.passed).toBe(false);
+      expect(result.details).toContain('not a JSON object');
+    });
+  });
+
+  describe('runAll', () => {
+    it('returns passed=true when all assertions pass', () => {
+      const descriptors: AssertionDescriptor[] = [
+        { type: 'contains', value: 'refund' },
+        { type: 'max_length', value: 500 },
+      ];
+      const result = assertions.runAll('Your refund is on the way', descriptors);
+      expect(result.passed).toBe(true);
+      expect(result.results).toHaveLength(2);
+      expect(result.results.every((r) => r.passed)).toBe(true);
+    });
+
+    it('returns passed=false when any assertion fails', () => {
+      const descriptors: AssertionDescriptor[] = [
+        { type: 'contains', value: 'refund' },
+        { type: 'max_length', value: 5 },
+      ];
+      const result = assertions.runAll('Your refund is on the way', descriptors);
+      expect(result.passed).toBe(false);
+      expect(result.results[0].passed).toBe(true);
+      expect(result.results[1].passed).toBe(false);
+    });
+
+    it('handles all assertion types', () => {
+      const content = '{"status":"ok","count":3}';
+      const descriptors: AssertionDescriptor[] = [
+        { type: 'contains', value: 'ok' },
+        { type: 'not_contains', value: 'error' },
+        { type: 'max_length', value: 100 },
+        { type: 'min_length', value: 5 },
+        { type: 'regex', value: '\\d+' },
+        { type: 'is_json', value: '' },
+        { type: 'json_schema', value: { status: 'string', count: 'number' } },
+      ];
+      const result = assertions.runAll(content, descriptors);
+      expect(result.passed).toBe(true);
+      expect(result.results).toHaveLength(7);
+    });
+
+    it('returns empty results for empty descriptors', () => {
+      const result = assertions.runAll('any content', []);
+      expect(result.passed).toBe(true);
+      expect(result.results).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `assertions` namespace with 7 individual assertion functions: `contains`, `notContains`, `maxLength`, `minLength`, `matchesRegex`, `isJson`, `matchesJsonSchema`
- Adds `runAll()` for batch execution of multiple assertions with aggregate pass/fail result
- All functions are standalone and synchronous — no API calls, no config needed
- Exported from package root: `import { assertions } from 'promptcanary'`
- New types: `AssertionDescriptor`, `RunAllResult`
- 30 unit tests covering all assertion types, edge cases, and runAll with mixed pass/fail

Closes #66