### PR TITLE
docs: rewrite README to lead with testing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     <img src="docs/public/logo-banner.png" width="500" alt="PromptCanary" />
   </a>
   <br>
-  <em>Uptime monitoring for AI behavior. Catch model drift before your users do.</em>
+  <em>Test your prompts like you test your code.</em>
   <br><br>
   <a href="https://github.com/VebjornNyvoll/promptcanary/actions"><img src="https://img.shields.io/github/actions/workflow/status/VebjornNyvoll/promptcanary/ci.yml?branch=master&label=build" alt="Build" /></a>
   <a href="https://www.npmjs.com/package/promptcanary"><img src="https://img.shields.io/npm/v/promptcanary" alt="npm" /></a>
@@ -20,57 +20,98 @@
 
 ## What is PromptCanary?
 
-LLM providers silently update models, deprecate versions, and shift behavior — often without warning. PromptCanary continuously runs your prompts against live models and compares responses against expectations, so you find out about regressions _before_ your users do.
+LLM providers silently update models, deprecate versions, and shift behavior — often without warning. PromptCanary lets you add prompt regression tests directly to your existing test suite, so you catch drift the same way you catch bugs.
 
 ```bash
-npm install -g promptcanary
+npm install promptcanary
 ```
 
 ## How it works
 
-**1. Define** what you expect from your prompts:
-
-```yaml
-# promptcanary.yaml
-prompts:
-  - name: pricing-faq
-    provider: openai
-    model: gpt-4o-mini
-    messages:
-      - role: user
-        content: 'What is the refund policy?'
-    assertions:
-      - type: contains
-        value: '30 days'
-      - type: max_length
-        value: 500
-```
-
-**2. Run** tests on demand or on a schedule:
+**1. Install** as a dev dependency:
 
 ```bash
-promptcanary run promptcanary.yaml --verbose
+npm install --save-dev promptcanary
 ```
 
-**3. Get alerted** when behavior drifts — via Slack, webhooks, or CI failures.
+**2. Write tests** alongside your existing test suite:
+
+```typescript
+import { describe, it, expect } from 'vitest'; // or jest, mocha, etc.
+import { testPrompt, assertions } from 'promptcanary';
+
+describe('refund policy prompt', () => {
+  it('mentions the 30-day window', async () => {
+    const result = await testPrompt({
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: 'What is the refund policy?' }],
+    });
+
+    expect(assertions.contains(result.content, '30 days').passed).toBe(true);
+    expect(assertions.maxLength(result.content, 500).passed).toBe(true);
+  });
+});
+```
+
+**3. Run** with your test runner — in dev, in CI, everywhere:
+
+```bash
+npx vitest run
+```
 
 ## Features
 
-**Multi-provider testing** — Test across OpenAI, Anthropic, and Google Gemini simultaneously. Catch provider-specific regressions.
+**Works with any test runner** — Vitest, Jest, Mocha, or anything that runs TypeScript/JavaScript. No proprietary test format required.
+
+**Multi-provider testing** — Test across OpenAI, Anthropic, and Google Gemini. Catch provider-specific regressions by running the same prompt against multiple models.
 
 **Semantic similarity** — Go beyond string matching. Embedding-based comparison detects subtle meaning shifts that keyword checks miss.
 
-**Structural assertions** — Validate response length, required content, JSON schema conformance, regex patterns, and more.
+**Built-in assertions** — `contains`, `notContains`, `maxLength`, `minLength`, `matchesRegex`, `isJson`, `matchesJsonSchema`, plus `runAll()` for batch checks.
 
-**Continuous monitoring** — Schedule tests on cron intervals. Pair with `promptcanary cleanup` for automatic data retention.
+**CI/CD native** — Runs wherever your tests run. GitHub Actions, GitLab CI, any pipeline. Non-zero exit on failures.
 
-**Instant alerting** — Slack and webhook notifications with deduplication. Don't find out from your users.
-
-**CI/CD ready** — Run in GitHub Actions, GitLab CI, or any pipeline. Non-zero exit on failures.
-
-**Zero infrastructure** — Single binary, SQLite storage. No database to manage, no servers to provision.
+**Zero infrastructure** — One npm package. No servers, no dashboards, no separate tools.
 
 ## Quick Start
+
+```typescript
+import { testPrompt, semanticSimilarity, assertions } from 'promptcanary';
+
+// Test a prompt and check the response
+const result = await testPrompt({
+  provider: 'openai',
+  model: 'gpt-4o-mini',
+  messages: [{ role: 'user', content: 'Summarize our return policy' }],
+});
+
+// Individual assertions
+assertions.contains(result.content, 'refund'); // { passed: true, ... }
+assertions.maxLength(result.content, 500); // { passed: true, ... }
+assertions.isJson(result.content); // { passed: false, ... }
+
+// Batch assertions
+const check = assertions.runAll(result.content, [
+  { type: 'contains', value: 'refund' },
+  { type: 'max_length', value: 500 },
+  { type: 'regex', value: '\\d+ days' },
+]);
+// check.passed → true/false, check.results → individual results
+
+// Semantic similarity (requires OPENAI_API_KEY for embeddings)
+const score = await semanticSimilarity(
+  result.content,
+  'Customers can request a full refund within 30 days of purchase.',
+);
+// score → 0.0 to 1.0
+```
+
+See the [Getting Started guide](https://vebjornnyvoll.github.io/promptcanary/getting-started) for a full walkthrough.
+
+## CLI Usage
+
+For teams that prefer YAML config over code, PromptCanary also ships with a CLI:
 
 ```bash
 # Install globally
@@ -79,43 +120,26 @@ npm install -g promptcanary
 # Create a config file
 promptcanary init
 
-# Run your prompt tests
+# Run prompt tests from YAML config
 promptcanary run promptcanary.yaml --verbose
-
-# View historical results
-promptcanary results
 
 # Output as JSON for CI pipelines
 promptcanary run promptcanary.yaml --json
-```
-
-See the [Getting Started guide](https://vebjornnyvoll.github.io/promptcanary/getting-started) for a full walkthrough.
-
-## Programmatic API
-
-```typescript
-import { PromptCanary } from 'promptcanary';
-
-const canary = new PromptCanary();
-const results = await canary.run('./promptcanary.yaml');
-
-for (const result of results) {
-  console.log(`${result.name}: ${result.pass ? 'PASS' : 'FAIL'}`);
-}
 ```
 
 ## Documentation
 
 Full documentation is available at **[vebjornnyvoll.github.io/promptcanary](https://vebjornnyvoll.github.io/promptcanary/)**.
 
-|                                                                             |                                        |
-| --------------------------------------------------------------------------- | -------------------------------------- |
-| [Configuration](https://vebjornnyvoll.github.io/promptcanary/configuration) | YAML config reference and examples     |
-| [Providers](https://vebjornnyvoll.github.io/promptcanary/providers)         | OpenAI, Anthropic, Google Gemini setup |
-| [Assertions](https://vebjornnyvoll.github.io/promptcanary/assertions)       | All assertion types and usage          |
-| [CLI Reference](https://vebjornnyvoll.github.io/promptcanary/cli)           | Command-line interface docs            |
-| [API Reference](https://vebjornnyvoll.github.io/promptcanary/api)           | Programmatic usage                     |
-| [Architecture](https://vebjornnyvoll.github.io/promptcanary/architecture)   | Design and data flow                   |
+|                                                                                 |                                        |
+| ------------------------------------------------------------------------------- | -------------------------------------- |
+| [Getting Started](https://vebjornnyvoll.github.io/promptcanary/getting-started) | Installation and first test            |
+| [Providers](https://vebjornnyvoll.github.io/promptcanary/providers)             | OpenAI, Anthropic, Google Gemini setup |
+| [Assertions](https://vebjornnyvoll.github.io/promptcanary/assertions)           | All assertion types and usage          |
+| [API Reference](https://vebjornnyvoll.github.io/promptcanary/api)               | Programmatic API docs                  |
+| [CI/CD Guide](https://vebjornnyvoll.github.io/promptcanary/ci-cd)               | GitHub Actions, GitLab CI setup        |
+| [CLI Reference](https://vebjornnyvoll.github.io/promptcanary/cli)               | Command-line interface docs            |
+| [Architecture](https://vebjornnyvoll.github.io/promptcanary/architecture)       | Design and data flow                   |
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Repositions hero tagline from "Uptime monitoring for AI behavior" to "Test your prompts like you test your code"
- Primary example now shows Vitest integration with `testPrompt()` and `assertions`
- "How it works" section shows install → write tests → run with test runner
- Features section leads with test-runner compatibility
- Quick Start shows programmatic API (testPrompt, assertions, semanticSimilarity)
- CLI usage moved to its own section below the fold
- Updated docs table with Getting Started and CI/CD Guide links

Closes #67