### PR TITLE
docs: rewrite getting-started guide for programmatic API

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,43 +1,20 @@
 # Getting Started
 
-This guide gets PromptCanary running end to end: install, configure credentials, run tests, and inspect results.
+Add prompt regression tests to your existing test suite in under five minutes.
 
-## 1) Install PromptCanary
+## Installation
 
-Install globally to use the `promptcanary` CLI command anywhere:
-
-```bash
-npm install -g promptcanary
-```
-
-## 2) Set up API keys
-
-PromptCanary reads API keys from environment variables.
-
-### Local development with `.env`
-
-The CLI auto-loads `.env` in the current directory.
+Install PromptCanary as a dev dependency:
 
 ```bash
-cp .env.example .env
-# Edit .env with your keys
-promptcanary run promptcanary.yaml
+npm install --save-dev promptcanary
 ```
 
-Use `--dotenv` to load a file from another path:
+## Set up API keys
 
-```bash
-promptcanary --dotenv ~/.config/promptcanary/.env run promptcanary.yaml
-```
+PromptCanary calls LLM providers on your behalf, so it needs API keys via environment variables.
 
-Notes:
-
-- `.env` is gitignored by default and should never be committed.
-- `dotenv` does not overwrite variables that are already set in your shell.
-
-### Shell profile setup
-
-Set variables in your shell profile (`~/.bashrc`, `~/.zshrc`, or PowerShell profile):
+Set the key for whichever provider(s) you test against:
 
 ```bash
 export OPENAI_API_KEY="sk-..."
@@ -45,54 +22,152 @@ export ANTHROPIC_API_KEY="sk-ant-..."
 export GOOGLE_API_KEY="AIza..."
 ```
 
-### CI/CD setup
+For local development, add these to a `.env` file (and make sure it's in `.gitignore`). Most test runners and CI systems support environment variables natively.
 
-Use your CI provider secrets manager and inject env vars at runtime:
+## Your first prompt test
+
+Create a test file next to your existing tests. This example uses Vitest, but any runner works:
+
+```typescript
+// tests/prompts/refund-policy.test.ts
+import { describe, it, expect } from 'vitest';
+import { testPrompt, assertions } from 'promptcanary';
+
+describe('refund policy prompt', () => {
+  it('mentions the 30-day window', async () => {
+    const result = await testPrompt({
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: 'What is our refund policy?' }],
+    });
+
+    expect(assertions.contains(result.content, '30 days').passed).toBe(true);
+    expect(assertions.maxLength(result.content, 500).passed).toBe(true);
+  });
+
+  it('stays under token budget', async () => {
+    const result = await testPrompt({
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: 'Summarize the return process' }],
+    });
+
+    expect(result.tokenUsage.completion).toBeLessThan(200);
+  });
+});
+```
+
+### What `testPrompt()` returns
+
+```typescript
+{
+  content: string; // The model's response text
+  model: string; // Model that responded (e.g. "gpt-4o-mini")
+  provider: string; // Provider name ("openai", "anthropic", "google")
+  latencyMs: number; // Response time in milliseconds
+  tokenUsage: {
+    prompt: number; // Input tokens
+    completion: number; // Output tokens
+  }
+}
+```
+
+## Using assertions
+
+PromptCanary ships assertion helpers that return structured results:
+
+```typescript
+import { assertions } from 'promptcanary';
+
+// Each returns { passed: boolean, type: string, expected: string, actual: string, details?: string }
+assertions.contains(content, 'refund');
+assertions.notContains(content, 'error');
+assertions.maxLength(content, 500);
+assertions.minLength(content, 50);
+assertions.matchesRegex(content, /\d+ days/);
+assertions.isJson(content);
+assertions.matchesJsonSchema(content, { status: 'string', count: 'number' });
+
+// Batch multiple assertions
+const check = assertions.runAll(content, [
+  { type: 'contains', value: 'refund' },
+  { type: 'max_length', value: 500 },
+]);
+// check.passed → true if all pass, check.results → individual results
+```
+
+## Semantic similarity
+
+Compare response meaning using embeddings (requires `OPENAI_API_KEY`):
+
+```typescript
+import { testPrompt, semanticSimilarity } from 'promptcanary';
+
+const result = await testPrompt({
+  provider: 'openai',
+  model: 'gpt-4o-mini',
+  messages: [{ role: 'user', content: 'Explain our cancellation policy' }],
+});
+
+const score = await semanticSimilarity(
+  result.content,
+  'Users may cancel their subscription at any time with no penalty.',
+);
+
+expect(score).toBeGreaterThan(0.8);
+```
+
+## Running tests
+
+Run with your normal test command — there's nothing special about prompt tests:
+
+```bash
+# Vitest
+npx vitest run
+
+# Jest
+npx jest
+
+# Or however you run tests
+npm test
+```
+
+## Using in CI
+
+Since prompt tests are regular test files, they run wherever your tests run. Set API keys as secrets in your CI provider:
 
 ```yaml
-- run: promptcanary run promptcanary.yaml
+# .github/workflows/ci.yml
+- name: Run tests
+  run: npm test
   env:
     OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-    GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
 ```
 
-### Docker and production setup
+See the [CI/CD Guide](./ci-cd.md) for GitHub Actions, GitLab CI, and JSON output examples.
 
-Pass keys via environment variables and use your platform secret manager:
+## Alternative: CLI usage
 
-```bash
-docker run -e OPENAI_API_KEY="$OPENAI_API_KEY" -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" -e GOOGLE_API_KEY="$GOOGLE_API_KEY" promptcanary run promptcanary.yaml
-```
-
-## 3) Create a config file
-
-Generate starter config from the built-in template:
+For quick checks without a test suite, or for teams that prefer config-driven testing:
 
 ```bash
+# Install the CLI globally
+npm install -g promptcanary
+
+# Generate a YAML config
 promptcanary init
-```
 
-This creates `promptcanary.yaml` in your current directory.
-
-## 4) Run your first test suite
-
-Run all configured tests and providers with verbose progress output:
-
-```bash
+# Run tests from config
 promptcanary run promptcanary.yaml --verbose
+
+# Output JSON for CI parsing
+promptcanary run promptcanary.yaml --json
 ```
 
-## 5) View stored results
+See the [CLI Reference](./cli.md) for full command documentation.
 
-Inspect recent test runs from SQLite:
+## Next steps
 
-```bash
-promptcanary results
-```
-
-## 6) Next steps
-
-- Enable continuous monitoring with `promptcanary monitor promptcanary.yaml`
-- Add CI checks in pull requests
-- Configure Slack or webhook alerts for failures
+- Browse the [API Reference](./api.md) for all exported functions and types
+- Set up [multiple providers](./providers.md) to test across OpenAI, Anthropic, and Google Gemini
+- Read the [Assertions guide](./assertions.md) for all available assertion types


### PR DESCRIPTION
## Summary

- Primary path is now: install as dev dependency → write test files with `testPrompt()` → run with vitest/jest
- Documents `testPrompt()` return type, assertion helpers, `semanticSimilarity()`, and `runAll()`
- CI section points to CI/CD guide — "it's just your test suite"
- CLI/YAML flow moved to "Alternative: CLI usage" section at the bottom
- Updated next-steps links

Closes #68