### PR TITLE
fix: run build before test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Lint
         run: pnpm lint
 
-      - name: Test
-        run: pnpm test
-
       - name: Build
         run: pnpm build
+
+      - name: Test
+        run: pnpm test


### PR DESCRIPTION
## Summary

- Swaps Build and Test step order in CI workflow
- CLI integration tests spawn `node dist/cli/index.js` as a child process, which requires the built output to exist
- Previously Build ran after Test, causing 7 CLI tests to fail with `MODULE_NOT_FOUND` on every CI run across all 6 matrix jobs