### PR TITLE
release: 0.2.0 — first-class testing API

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
       { text: 'Reference', link: '/configuration' },
       { text: 'API', link: '/api' },
       {
-        text: 'v0.1.0',
+        text: 'v0.2.0',
         items: [
           { text: 'Changelog', link: '/changelog' },
           { text: 'npm', link: 'https://www.npmjs.com/package/promptcanary' },

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-03-04
+
+### Added
+
+- `testPrompt()` — standalone function to send prompts to any provider and get typed results
+- `semanticSimilarity()` — compute cosine similarity between two strings using OpenAI embeddings
+- `assertions` namespace — 7 synchronous assertion helpers (`contains`, `notContains`, `maxLength`, `minLength`, `matchesRegex`, `isJson`, `matchesJsonSchema`) plus `runAll()` for batch execution
+- New types: `TestPromptOptions`, `TestPromptResult`, `ChatMessage`, `SemanticSimilarityOptions`, `AssertionDescriptor`, `RunAllResult`
+- 45 new unit tests for the testing API
+
+### Changed
+
+- README repositioned from monitoring tool to testing library
+- Getting started guide leads with programmatic API (Vitest/Jest) instead of CLI
+- API reference rewritten to lead with `testPrompt()`, `semanticSimilarity()`, and `assertions`
+- "What is PromptCanary?" intro page updated for testing library identity
+- Docs sidebar reorganized: monitoring and alerting moved to Advanced section
+- Configuration renamed to "Configuration (YAML)" in sidebar
+- package.json description and keywords updated for npm discoverability
+
+### Fixed
+
+- CI workflow now runs Build before Test so CLI integration tests find `dist/` output
+
 ## [0.1.0] - 2026-03-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptcanary",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Test your LLM prompts like you test your code. Assertions, semantic similarity, and multi-provider testing for Vitest, Jest, and any test runner.",
   "author": {
     "name": "Vebjørn Nyvoll",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export const VERSION = '0.1.0';
+export const VERSION = '0.2.0';
 
 // Schema exports
 export {

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -4,6 +4,6 @@ import { VERSION } from '../src/index.js';
 
 describe('smoke', () => {
   it('exports the expected version', () => {
-    expect(VERSION).toBe('0.1.0');
+    expect(VERSION).toBe('0.2.0');
   });
 });


### PR DESCRIPTION
## Summary

Version bump to 0.2.0 for the First-Class Testing API milestone.

### New in 0.2.0
- `testPrompt()` — send prompts to any provider, get typed results
- `semanticSimilarity()` — embedding-based similarity scoring
- `assertions` namespace — 7 assertion helpers + `runAll()`
- 45 new tests, full docs rewrite, CI fix

### Files changed
- `package.json` — version bump
- `src/index.ts` — VERSION constant
- `docs/.vitepress/config.ts` — nav version
- `docs/changelog.md` — 0.2.0 entry
- `tests/smoke.test.ts` — version assertion