### PR TITLE
Clean up remaining monitoring/alerting references

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,8 @@
 layout: home
 hero:
   name: PromptCanary
-  text: Uptime monitoring for AI behavior
-  tagline: Catch model drift before your users do. Continuously test your prompts, compare responses, and get alerted when behavior changes.
+  text: Test your prompts like you test your code
+  tagline: Catch model drift before your users do. Add prompt regression tests to your existing test suite — Vitest, Jest, or any JavaScript test runner.
   actions:
     - theme: brand
       text: Get Started
@@ -12,22 +12,22 @@ hero:
       text: View on GitHub
       link: https://github.com/VebjornNyvoll/promptcanary
 features:
-  - title: Continuous Monitoring
-    details: Schedule automatic prompt tests on a cron interval. Detect regressions before users report them.
-    icon: 🔄
+  - title: Works With Any Test Runner
+    details: Regular functions that work in Vitest, Jest, Mocha, or any runner. No proprietary test format, no separate tool.
+    icon: ✅
   - title: Multi-Provider Testing
-    details: Test across OpenAI, Anthropic, and Google Gemini simultaneously. Catch provider-specific drift.
+    details: Test across OpenAI, Anthropic, and Google Gemini simultaneously. Catch provider-specific regressions.
     icon: 🔀
   - title: Semantic Similarity
     details: Go beyond string matching. Embedding-based comparison detects subtle meaning shifts in responses.
     icon: 🧠
-  - title: Instant Alerts
-    details: Get notified via Slack or webhooks when prompts break. Do not find out from your users.
-    icon: 🚨
-  - title: CI/CD Integration
-    details: Run prompt tests in your pipeline. Catch regressions before they hit production.
+  - title: Built-in Assertions
+    details: contains, notContains, maxLength, minLength, matchesRegex, isJson, matchesJsonSchema, plus runAll() for batch checks.
+    icon: 🔍
+  - title: CI/CD Native
+    details: Runs wherever your tests run. GitHub Actions, GitLab CI, any pipeline. Non-zero exit on failures.
     icon: ⚡
   - title: Zero Infrastructure
-    details: Single binary, SQLite storage. No database to manage, no servers to provision.
+    details: One npm package. No servers, no dashboards, no separate tools to manage.
     icon: 📦
 ---

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -64,24 +64,6 @@ Fix:
 - Check required top-level fields: `version`, `config.providers`, `tests`.
 - Ensure `min_length <= max_length` when both are set.
 
-### `monitor` fails on startup
-
-Likely cause:
-
-- Missing `config.schedule`, or invalid cron expression.
-
-Fix:
-
-- Add a valid five-field cron expression, for example `0 */6 * * *`.
-
-### Webhook alerts not arriving
-
-Check:
-
-- URL starts with `http://` or `https://`.
-- Destination endpoint accepts `application/json`.
-- Custom auth headers are configured correctly.
-
 ## FAQ
 
 ### Where is run data stored?


### PR DESCRIPTION
## Summary

Final sweep to remove all remaining monitoring/alerting references from the docs site.

## Changes

| File | Change |
|---|---|
| `docs/index.md` | Rewrote homepage hero text and features — replaced "Uptime monitoring", "Continuous Monitoring", and "Instant Alerts" with testing library positioning |
| `docs/troubleshooting.md` | Removed `monitor` command and webhook alerting troubleshooting sections |

All verification passed: tsc, eslint, vitest (180 tests), build, docs:build.

Closes #87