### PR TITLE
Release 1.0.0 — Remove monitoring and alerting

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
       { text: 'Reference', link: '/configuration' },
       { text: 'API', link: '/api' },
       {
-        text: 'v0.2.0',
+        text: 'v1.0.0',
         items: [
           { text: 'Changelog', link: '/changelog' },
           { text: 'npm', link: 'https://www.npmjs.com/package/promptcanary' },

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-03-04
+
+### Removed
+
+- **`monitor` command** — use CI/CD scheduled workflows (cron) with `promptcanary run` instead
+- **`cleanup` command** — no longer needed without continuous monitoring
+- **Scheduler** (`startScheduler`, `executeRun`) — removed from public API
+- **Alerting system** — Slack, webhook, `dispatchAlerts`, `createAlertChannels` all removed. Use your existing alerting infrastructure (PagerDuty, Datadog, CI notifications, etc.)
+- **Alert types** — `AlertConfig`, `AlertPayload`, `AlertChannel`, `AlertConfigSchema` removed
+- **`schedule` config field** — no longer part of the configuration schema
+- **`node-cron` dependency** — no longer needed
+
+### Migration from 0.2.0
+
+If you were using `promptcanary monitor`:
+
+- Replace with a CI/CD scheduled workflow (e.g., GitHub Actions `schedule`, GitLab CI schedule, or a system cron job) that runs `promptcanary run your-config.yaml`
+
+If you were using alerting (Slack/webhook):
+
+- Use your CI/CD pipeline's built-in notification system. PromptCanary exits with code `1` on failures, which triggers standard CI alerts automatically.
+
+If you were using the `cleanup` command:
+
+- No replacement needed. Without continuous monitoring, database growth is minimal.
+
+If you imported `startScheduler`, `executeRun`, or alert types:
+
+- Remove these imports. Use `testPrompt()`, `assertions`, and `semanticSimilarity()` for programmatic testing instead.
+
 ## [0.2.0] - 2026-03-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptcanary",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Test your LLM prompts like you test your code. Assertions, semantic similarity, and multi-provider testing for Vitest, Jest, and any test runner.",
   "author": {
     "name": "Vebjørn Nyvoll",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export const VERSION = '0.2.0';
+export const VERSION = '1.0.0';
 
 // Schema exports
 export {

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -4,6 +4,6 @@ import { VERSION } from '../src/index.js';
 
 describe('smoke', () => {
   it('exports the expected version', () => {
-    expect(VERSION).toBe('0.2.0');
+    expect(VERSION).toBe('1.0.0');
   });
 });


### PR DESCRIPTION
## Summary

Bumps PromptCanary to 1.0.0, marking the completion of the monitoring/alerting deprecation (Milestone 23).

## What changed

- Version bumped to `1.0.0` in `package.json`, `src/index.ts`, `docs/.vitepress/config.ts`, `tests/smoke.test.ts`
- Changelog entry added with full list of removed features and migration guide

## Breaking changes (since 0.2.0)

**Removed:**
- `monitor` CLI command
- `cleanup` CLI command
- `startScheduler()` and `executeRun()` from public API
- Alerting system (Slack, webhook, `dispatchAlerts`, `createAlertChannels`)
- Alert types (`AlertConfig`, `AlertPayload`, `AlertChannel`, `AlertConfigSchema`)
- `schedule` config field
- `node-cron` dependency

**Migration:** See changelog for full migration guide.

## Verification

- 180 tests passing across 16 files
- TypeScript, ESLint, build, and docs build all clean

Closes #88