### PR TITLE
Closes #98

### DIFF
--- a/.github/actions/run/README.md
+++ b/.github/actions/run/README.md
@@ -1,0 +1,96 @@
+# PromptCanary GitHub Action
+
+Run PromptCanary prompt regression tests in GitHub Actions with minimal configuration.
+
+## Usage (minimal setup)
+
+```yaml
+name: Prompt Tests
+
+on:
+  pull_request:
+    paths:
+      - 'promptcanary.yaml'
+      - 'prompts/**'
+
+jobs:
+  prompt-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: VebjornNyvoll/promptcanary/.github/actions/run@master
+        with:
+          config: promptcanary.yaml
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+```
+
+## Inputs
+
+| Input          | Required | Default             | Description                                             |
+| -------------- | -------- | ------------------- | ------------------------------------------------------- |
+| `config`       | Yes      | `promptcanary.yaml` | Path to PromptCanary YAML config file                   |
+| `version`      | No       | `latest`            | PromptCanary version to run via `npx`                   |
+| `verbose`      | No       | `false`             | Enable verbose output (`--verbose`)                     |
+| `json`         | No       | `false`             | Enable JSON output (`--json`)                           |
+| `node-version` | No       | `20`                | Node.js version used by `actions/setup-node`            |
+| `args`         | No       | `''`                | Additional CLI arguments appended to `promptcanary run` |
+
+## Secrets and API keys
+
+Pass provider API keys as environment variables (recommended via repository/workflow secrets), not action inputs.
+
+```yaml
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+```
+
+## Examples
+
+### Basic usage
+
+```yaml
+- uses: VebjornNyvoll/promptcanary/.github/actions/run@master
+  with:
+    config: promptcanary.yaml
+  env:
+    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+```
+
+### Verbose output
+
+```yaml
+- uses: VebjornNyvoll/promptcanary/.github/actions/run@master
+  with:
+    config: promptcanary.yaml
+    verbose: true
+  env:
+    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+```
+
+### JSON output
+
+```yaml
+- uses: VebjornNyvoll/promptcanary/.github/actions/run@master
+  with:
+    config: promptcanary.yaml
+    json: true
+  env:
+    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+```
+
+### Multiple providers
+
+```yaml
+- uses: VebjornNyvoll/promptcanary/.github/actions/run@master
+  with:
+    config: promptcanary.yaml
+    verbose: true
+  env:
+    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+```

--- a/.github/actions/run/action.yml
+++ b/.github/actions/run/action.yml
@@ -1,0 +1,49 @@
+name: 'PromptCanary'
+description: 'Run LLM prompt regression tests in your CI pipeline'
+author: 'VebjornNyvoll'
+
+branding:
+  icon: 'check-circle'
+  color: 'yellow'
+
+inputs:
+  config:
+    description: 'Path to promptcanary YAML config file'
+    required: true
+    default: 'promptcanary.yaml'
+  version:
+    description: 'PromptCanary version to use'
+    required: false
+    default: 'latest'
+  verbose:
+    description: 'Enable verbose output'
+    required: false
+    default: 'false'
+  json:
+    description: 'Output results as JSON'
+    required: false
+    default: 'false'
+  node-version:
+    description: 'Node.js version to use'
+    required: false
+    default: '20'
+  args:
+    description: 'Additional CLI arguments'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Run PromptCanary
+      shell: bash
+      run: |
+        FLAGS=""
+        if [ "${{ inputs.verbose }}" = "true" ]; then FLAGS="$FLAGS --verbose"; fi
+        if [ "${{ inputs.json }}" = "true" ]; then FLAGS="$FLAGS --json"; fi
+        npx promptcanary@${{ inputs.version }} run ${{ inputs.config }} $FLAGS ${{ inputs.args }}

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -111,6 +111,19 @@ jobs:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
 ```
 
+### Using the PromptCanary action
+
+As an alternative to running `npx` directly, you can use the built-in PromptCanary composite action:
+
+```yaml
+- uses: VebjornNyvoll/promptcanary/.github/actions/run@master
+  with:
+    config: promptcanary.yaml
+    verbose: true
+  env:
+    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+```
+
 ## GitLab CI
 
 ```yaml


### PR DESCRIPTION
## Summary
- add a composite GitHub Action at `.github/actions/run/action.yml` to run PromptCanary in CI with minimal setup
- document action usage and inputs in `.github/actions/run/README.md`, including env-based API key guidance and examples
- add a CI/CD docs section showing the action as an alternative setup method

Closes #98