### PR TITLE
Add init --test-runner scaffolding for Vitest and Jest

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,6 +20,17 @@ Creates starter `promptcanary.yaml` in the current directory.
 promptcanary init
 ```
 
+Options:
+
+- `--test-runner <type>`: also scaffold `promptcanary.test.ts` using `vitest` or `jest`
+
+Examples:
+
+```bash
+promptcanary init --test-runner vitest
+promptcanary init --test-runner jest
+```
+
 ## `promptcanary validate <file>`
 
 Loads and validates config file.

--- a/examples/template.jest.ts
+++ b/examples/template.jest.ts
@@ -1,0 +1,19 @@
+import { testPrompt, assertions } from 'promptcanary';
+
+declare const describe: (name: string, fn: () => void) => void;
+declare const it: (name: string, fn: () => Promise<void>) => void;
+declare const expect: (value: unknown) => { toBe: (expected: unknown) => void };
+
+describe('prompt tests', () => {
+  it('responds with expected content', async () => {
+    // Set your API key: export OPENAI_API_KEY="sk-..."
+    const result = await testPrompt({
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: 'Say hello in one sentence' }],
+    });
+
+    expect(assertions.contains(result.content, 'hello').passed).toBe(true);
+    expect(assertions.maxLength(result.content, 200).passed).toBe(true);
+  });
+});

--- a/examples/template.vitest.ts
+++ b/examples/template.vitest.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { testPrompt, assertions } from 'promptcanary';
+
+describe('prompt tests', () => {
+  it('responds with expected content', async () => {
+    // Set your API key: export OPENAI_API_KEY="sk-..."
+    const result = await testPrompt({
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: 'Say hello in one sentence' }],
+    });
+
+    expect(assertions.contains(result.content, 'hello').passed).toBe(true);
+    expect(assertions.maxLength(result.content, 200).passed).toBe(true);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
   "files": [
     "dist",
     "examples",
+    "examples/template.vitest.ts",
+    "examples/template.jest.ts",
     "README.md",
     "LICENSE",
     "CHANGELOG.md",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -32,6 +32,8 @@ const ansi = {
 
 const here = fileURLToPath(new URL('.', import.meta.url));
 const templatePath = resolve(here, '../../examples/basic.yaml');
+const vitestTemplatePath = resolve(here, '../../examples/template.vitest.ts');
+const jestTemplatePath = resolve(here, '../../examples/template.jest.ts');
 
 function loadEnvironment(envFile?: string): void {
   if (envFile) {
@@ -61,8 +63,17 @@ program
 program
   .command('init')
   .description('Create a starter promptcanary.yaml in the current directory')
-  .action(async () => {
+  .option('--test-runner <type>', 'Generate a test file for your test runner (vitest or jest)')
+  .action(async (options: { testRunner?: string }) => {
+    const testRunner = options.testRunner;
+    if (testRunner !== undefined && testRunner !== 'vitest' && testRunner !== 'jest') {
+      printFailure('Invalid --test-runner value. Expected "vitest" or "jest".');
+      process.exitCode = 1;
+      return;
+    }
+
     const targetPath = resolve(process.cwd(), 'promptcanary.yaml');
+    const testTargetPath = resolve(process.cwd(), 'promptcanary.test.ts');
 
     try {
       await access(targetPath, constants.F_OK);
@@ -73,22 +84,39 @@ program
       // File does not exist; continue.
     }
 
-    await new Promise<void>((resolvePromise, rejectPromise) => {
-      copyFile(templatePath, targetPath, (error) => {
-        if (error) {
-          rejectPromise(error);
-          return;
-        }
-        resolvePromise();
-      });
-    });
+    if (testRunner) {
+      try {
+        await access(testTargetPath, constants.F_OK);
+        printWarning(`promptcanary.test.ts already exists at ${testTargetPath}`);
+        process.exitCode = 1;
+        return;
+      } catch {
+        // File does not exist; continue.
+      }
+    }
 
-    printSuccess(`Created promptcanary.yaml at ${targetPath}`);
+    await copyFileAsync(templatePath, targetPath);
+
+    if (testRunner) {
+      const sourcePath = testRunner === 'vitest' ? vitestTemplatePath : jestTemplatePath;
+      await copyFileAsync(sourcePath, testTargetPath);
+    }
+
+    printSuccess(
+      testRunner
+        ? `Created promptcanary.yaml and promptcanary.test.ts at ${process.cwd()}`
+        : `Created promptcanary.yaml at ${targetPath}`,
+    );
     printInfo('Next steps:');
     printInfo('1. Add your API keys to a .env file or export them in your shell');
     printInfo('2. Edit promptcanary.yaml with your prompts and expectations');
-    printInfo('3. Run: promptcanary validate promptcanary.yaml');
-    printInfo('4. Run: promptcanary run promptcanary.yaml');
+    if (testRunner) {
+      printInfo('3. Edit promptcanary.test.ts with your project-specific test cases');
+      printInfo(`4. Run your ${testRunner} test command to execute promptcanary.test.ts`);
+    } else {
+      printInfo('3. Run: promptcanary validate promptcanary.yaml');
+      printInfo('4. Run: promptcanary run promptcanary.yaml');
+    }
   });
 
 program
@@ -212,6 +240,18 @@ function parsePositiveInt(value: string): number {
     throw new InvalidArgumentError('Expected a positive integer.');
   }
   return parsed;
+}
+
+function copyFileAsync(sourcePath: string, destinationPath: string): Promise<void> {
+  return new Promise<void>((resolvePromise, rejectPromise) => {
+    copyFile(sourcePath, destinationPath, (error) => {
+      if (error) {
+        rejectPromise(error);
+        return;
+      }
+      resolvePromise();
+    });
+  });
 }
 
 async function applyComparisons(

--- a/tests/cli/index.test.ts
+++ b/tests/cli/index.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process';
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -78,6 +78,37 @@ describe('CLI integration', () => {
       const { stdout, exitCode } = await run(['init'], { cwd: tempDir });
       expect(exitCode).toBe(1);
       expect(stdout).toContain('already exists');
+    });
+
+    it('creates yaml and test file with --test-runner vitest', async () => {
+      const { stdout, exitCode } = await run(['init', '--test-runner', 'vitest'], { cwd: tempDir });
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('Created promptcanary.yaml and promptcanary.test.ts');
+      expect(existsSync(join(tempDir, 'promptcanary.yaml'))).toBe(true);
+      expect(existsSync(join(tempDir, 'promptcanary.test.ts'))).toBe(true);
+    });
+
+    it('creates yaml and test file with --test-runner jest', async () => {
+      const { stdout, exitCode } = await run(['init', '--test-runner', 'jest'], { cwd: tempDir });
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('Created promptcanary.yaml and promptcanary.test.ts');
+      expect(existsSync(join(tempDir, 'promptcanary.yaml'))).toBe(true);
+      expect(existsSync(join(tempDir, 'promptcanary.test.ts'))).toBe(true);
+    });
+
+    it('writes vitest import in generated test file', async () => {
+      const { exitCode } = await run(['init', '--test-runner', 'vitest'], { cwd: tempDir });
+      expect(exitCode).toBe(0);
+      const generated = readFileSync(join(tempDir, 'promptcanary.test.ts'), 'utf8');
+      expect(generated).toContain("import { describe, it, expect } from 'vitest';");
+    });
+
+    it('prints an error for invalid test runner', async () => {
+      const { stderr, exitCode } = await run(['init', '--test-runner', 'invalid'], {
+        cwd: tempDir,
+      });
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain('Invalid --test-runner value');
     });
   });
 

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "rootDir": "."
   },
-  "include": ["src/**/*", "tests/**/*.ts", "*.config.ts", "eslint.config.js"],
+  "include": ["src/**/*", "tests/**/*.ts", "examples/**/*.ts", "*.config.ts", "eslint.config.js"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- add `promptcanary init --test-runner <vitest|jest>` with validation and dual-file scaffolding
- add packaged test templates for Vitest and Jest, and extend CLI integration tests for new init behavior
- document the new init flag in CLI docs and update lint TS project coverage for example TS templates

Closes #96