### PR TITLE
feat: add variable interpolation in prompt messages

### DIFF
--- a/src/testing/testPrompt.ts
+++ b/src/testing/testPrompt.ts
@@ -11,6 +11,7 @@ import type { AssertionDescriptor } from './assertions.js';
 import { assertions } from './assertions.js';
 import { getProvider } from '../core/runner/providers/base.js';
 import { ResponseCache } from './responseCache.js';
+import { ConfigError } from '../types/index.js';
 import '../core/runner/providers/openai.js';
 import '../core/runner/providers/anthropic.js';
 import '../core/runner/providers/google.js';
@@ -36,12 +37,42 @@ function getLastUserMessageContent(messages: TestPromptOptions['messages']): str
   return '';
 }
 
+function interpolateMessages(
+  messages: TestPromptOptions['messages'],
+  variables: Record<string, string>,
+): TestPromptOptions['messages'] {
+  return messages.map((msg) => {
+    let content = msg.content;
+    for (const [key, value] of Object.entries(variables)) {
+      const pattern = new RegExp(
+        `\\{\\{\\s*${key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\}\\}`,
+        'g',
+      );
+      content = content.replace(pattern, value);
+    }
+
+    const remaining = content.match(/\{\{\s*\w+\s*\}\}/g);
+    if (remaining !== null) {
+      throw new ConfigError(
+        `Unresolved variables in message: ${remaining.join(', ')}. Provide values in the variables option.`,
+      );
+    }
+
+    return { ...msg, content };
+  });
+}
+
 export async function testPrompt(options: TestPromptOptions): Promise<TestPromptResult> {
+  const messages =
+    options.variables !== undefined && Object.keys(options.variables).length > 0
+      ? interpolateMessages(options.messages, options.variables)
+      : options.messages;
+
   if (options.cache === true) {
     const cacheKey = ResponseCache.buildCacheKey({
       provider: options.provider,
       model: options.model,
-      messages: options.messages,
+      messages,
       temperature: options.temperature,
     });
 
@@ -55,15 +86,18 @@ export async function testPrompt(options: TestPromptOptions): Promise<TestPrompt
       return { ...cached, cached: true };
     }
 
-    const result = await executePrompt(options);
+    const result = await executePrompt(options, messages);
     sharedCache.set(cacheKey, result);
     return result;
   }
 
-  return executePrompt(options);
+  return executePrompt(options, messages);
 }
 
-async function executePrompt(options: TestPromptOptions): Promise<TestPromptResult> {
+async function executePrompt(
+  options: TestPromptOptions,
+  messages: TestPromptOptions['messages'],
+): Promise<TestPromptResult> {
   const apiKeyEnv = providerApiKeyEnvMap[options.provider];
   const originalApiKey = process.env[apiKeyEnv];
   const providerConfig: ProviderConfig = {
@@ -81,7 +115,7 @@ async function executePrompt(options: TestPromptOptions): Promise<TestPromptResu
 
   try {
     const provider = getProvider(options.provider);
-    const prompt = getLastUserMessageContent(options.messages);
+    const prompt = getLastUserMessageContent(messages);
     const response = await provider.execute(prompt, providerConfig);
 
     return {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,6 +32,7 @@ export interface TestPromptOptions {
   timeoutMs?: number;
   cache?: boolean;
   cacheTtl?: number;
+  variables?: Record<string, string>;
 }
 
 export interface TestPromptResult {

--- a/tests/testing/testPrompt.test.ts
+++ b/tests/testing/testPrompt.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { testPrompt } from '../../src/testing/testPrompt.js';
-import { ProviderError, TimeoutError } from '../../src/types/index.js';
+import { ConfigError, ProviderError, TimeoutError } from '../../src/types/index.js';
 
 const {
   createCompletionMock,
@@ -266,5 +266,102 @@ describe('testPrompt', () => {
 
     await vi.advanceTimersByTimeAsync(10);
     await assertion;
+  });
+
+  it('interpolates {{variables}} in message content', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    createCompletionMock.mockResolvedValue({
+      model: 'gpt-4o-mini',
+      choices: [{ message: { content: 'interpolated response' } }],
+      usage: { prompt_tokens: 5, completion_tokens: 10 },
+    });
+
+    await testPrompt({
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      messages: [
+        { role: 'system', content: 'You are a {{role}} assistant.' },
+        { role: 'user', content: 'Explain {{topic}} in {{style}} terms.' },
+      ],
+      variables: {
+        role: 'customer support',
+        topic: 'our refund policy',
+        style: 'simple',
+      },
+    });
+
+    expect(createCompletionMock.mock.calls[0][0]).toMatchObject({
+      messages: [{ role: 'user', content: 'Explain our refund policy in simple terms.' }],
+    });
+  });
+
+  it('handles variables with whitespace in braces', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    createCompletionMock.mockResolvedValue({
+      model: 'gpt-4o-mini',
+      choices: [{ message: { content: 'ok' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    });
+
+    await testPrompt({
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: 'Hello {{ name }}' }],
+      variables: { name: 'World' },
+    });
+
+    expect(createCompletionMock.mock.calls[0][0]).toMatchObject({
+      messages: [{ role: 'user', content: 'Hello World' }],
+    });
+  });
+
+  it('throws ConfigError for unresolved variables', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+
+    await expect(
+      testPrompt({
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user', content: 'Hello {{name}} and {{missing}}' }],
+        variables: { name: 'World' },
+      }),
+    ).rejects.toBeInstanceOf(ConfigError);
+  });
+
+  it('works without variables option', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    createCompletionMock.mockResolvedValue({
+      model: 'gpt-4o-mini',
+      choices: [{ message: { content: 'ok' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    });
+
+    const result = await testPrompt({
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: 'No variables here' }],
+    });
+
+    expect(result.content).toBe('ok');
+  });
+
+  it('replaces multiple occurrences of same variable', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    createCompletionMock.mockResolvedValue({
+      model: 'gpt-4o-mini',
+      choices: [{ message: { content: 'ok' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    });
+
+    await testPrompt({
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: '{{x}} and {{x}}' }],
+      variables: { x: 'hello' },
+    });
+
+    expect(createCompletionMock.mock.calls[0][0]).toMatchObject({
+      messages: [{ role: 'user', content: 'hello and hello' }],
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `variables` option to `testPrompt()` for `{{variable}}` interpolation in message content
- Supports whitespace inside braces (`{{ name }}`) and multiple occurrences of same variable
- Throws `ConfigError` for unresolved variables (prevents silent template failures)
- Interpolation happens before caching, so cache keys reflect resolved content
- 5 new tests covering interpolation, whitespace, unresolved detection, no-op without variables, and repeat substitution

Closes #126
