### PR TITLE
feat: add expect.extend() matchers for Vitest and Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./matchers": {
+      "import": "./dist/matchers/index.js",
+      "types": "./dist/matchers/index.d.ts"
     }
   },
   "repository": {

--- a/src/matchers/index.ts
+++ b/src/matchers/index.ts
@@ -1,0 +1,220 @@
+import { assertions } from '../testing/assertions.js';
+
+interface MatcherResult {
+  pass: boolean;
+  message: () => string;
+}
+
+interface Expect {
+  extend: (matchers: Record<string, (...args: unknown[]) => MatcherResult>) => void;
+}
+
+function toContainPrompt(received: string, substring: string): MatcherResult {
+  const result = assertions.contains(received, substring);
+  return {
+    pass: result.passed,
+    message: () =>
+      result.passed
+        ? `Expected content not to contain "${substring}"`
+        : `Expected content to contain "${substring}", but it was not found`,
+  };
+}
+
+function toNotContainPrompt(received: string, substring: string): MatcherResult {
+  const result = assertions.notContains(received, substring);
+  return {
+    pass: result.passed,
+    message: () =>
+      result.passed
+        ? `Expected content to contain "${substring}"`
+        : `Expected content not to contain "${substring}", but it was found`,
+  };
+}
+
+function toStartWithPrompt(received: string, prefix: string): MatcherResult {
+  const result = assertions.startsWith(received, prefix);
+  return {
+    pass: result.passed,
+    message: () =>
+      result.passed
+        ? `Expected content not to start with "${prefix}"`
+        : `Expected content to start with "${prefix}"`,
+  };
+}
+
+function toEndWithPrompt(received: string, suffix: string): MatcherResult {
+  const result = assertions.endsWith(received, suffix);
+  return {
+    pass: result.passed,
+    message: () =>
+      result.passed
+        ? `Expected content not to end with "${suffix}"`
+        : `Expected content to end with "${suffix}"`,
+  };
+}
+
+function toContainAllPrompt(received: string, substrings: string[]): MatcherResult {
+  const result = assertions.containsAll(received, substrings);
+  return {
+    pass: result.passed,
+    message: () =>
+      result.passed
+        ? `Expected content not to contain all substrings`
+        : (result.details ?? 'Missing substrings'),
+  };
+}
+
+function toContainAnyPrompt(received: string, substrings: string[]): MatcherResult {
+  const result = assertions.containsAny(received, substrings);
+  return {
+    pass: result.passed,
+    message: () =>
+      result.passed
+        ? `Expected content not to contain any of the substrings`
+        : (result.details ?? 'None of the substrings found'),
+  };
+}
+
+function toMatchMaxLength(received: string, max: number): MatcherResult {
+  const result = assertions.maxLength(received, max);
+  return {
+    pass: result.passed,
+    message: () =>
+      result.passed
+        ? `Expected content to exceed ${String(max)} characters`
+        : (result.details ?? `Content exceeds max length of ${String(max)}`),
+  };
+}
+
+function toMatchMinLength(received: string, min: number): MatcherResult {
+  const result = assertions.minLength(received, min);
+  return {
+    pass: result.passed,
+    message: () =>
+      result.passed
+        ? `Expected content to be shorter than ${String(min)} characters`
+        : (result.details ?? `Content is shorter than ${String(min)}`),
+  };
+}
+
+function toMatchWordCount(
+  received: string,
+  options: { min?: number; max?: number },
+): MatcherResult {
+  const result = assertions.wordCount(received, options);
+  return {
+    pass: result.passed,
+    message: () =>
+      result.passed
+        ? `Expected word count to be outside range`
+        : (result.details ?? 'Word count out of range'),
+  };
+}
+
+function toMatchPromptRegex(received: string, pattern: RegExp | string): MatcherResult {
+  const result = assertions.matchesRegex(received, pattern);
+  return {
+    pass: result.passed,
+    message: () =>
+      result.passed
+        ? `Expected content not to match pattern ${String(pattern)}`
+        : `Expected content to match pattern ${String(pattern)}`,
+  };
+}
+
+function toBeValidJson(received: string): MatcherResult {
+  const result = assertions.isJson(received);
+  return {
+    pass: result.passed,
+    message: () =>
+      result.passed ? `Expected content not to be valid JSON` : `Expected content to be valid JSON`,
+  };
+}
+
+function toMatchJsonSchema(received: string, schema: Record<string, string>): MatcherResult {
+  const result = assertions.matchesJsonSchema(received, schema);
+  return {
+    pass: result.passed,
+    message: () =>
+      result.passed
+        ? `Expected content not to match JSON schema`
+        : (result.details ?? 'Content does not match JSON schema'),
+  };
+}
+
+function toMatchLevenshtein(received: string, expected: string, threshold?: number): MatcherResult {
+  const result = assertions.levenshtein(received, expected, { threshold });
+  return {
+    pass: result.passed,
+    message: () =>
+      result.passed
+        ? `Expected Levenshtein score to be below ${String(threshold)}`
+        : (result.details ?? 'Levenshtein score below threshold'),
+  };
+}
+
+function toMatchRouge1(received: string, reference: string, threshold?: number): MatcherResult {
+  const result = assertions.rouge1(received, reference, { threshold });
+  return {
+    pass: result.passed,
+    message: () =>
+      result.passed
+        ? `Expected ROUGE-1 score to be below ${String(threshold)}`
+        : (result.details ?? 'ROUGE-1 score below threshold'),
+  };
+}
+
+function toMatchBleu(received: string, reference: string, threshold?: number): MatcherResult {
+  const result = assertions.bleu(received, reference, { threshold });
+  return {
+    pass: result.passed,
+    message: () =>
+      result.passed
+        ? `Expected BLEU score to be below ${String(threshold)}`
+        : (result.details ?? 'BLEU score below threshold'),
+  };
+}
+
+const promptCanaryMatchers = {
+  toContainPrompt,
+  toNotContainPrompt,
+  toStartWithPrompt,
+  toEndWithPrompt,
+  toContainAllPrompt,
+  toContainAnyPrompt,
+  toMatchMaxLength,
+  toMatchMinLength,
+  toMatchWordCount,
+  toMatchPromptRegex,
+  toBeValidJson,
+  toMatchJsonSchema,
+  toMatchLevenshtein,
+  toMatchRouge1,
+  toMatchBleu,
+};
+
+export function extendExpect(expectFn: Expect): void {
+  expectFn.extend(
+    promptCanaryMatchers as unknown as Record<string, (...args: unknown[]) => MatcherResult>,
+  );
+}
+
+export { promptCanaryMatchers };
+
+export interface PromptCanaryMatchers<R = unknown> {
+  toContainPrompt(substring: string): R;
+  toNotContainPrompt(substring: string): R;
+  toStartWithPrompt(prefix: string): R;
+  toEndWithPrompt(suffix: string): R;
+  toContainAllPrompt(substrings: string[]): R;
+  toContainAnyPrompt(substrings: string[]): R;
+  toMatchMaxLength(max: number): R;
+  toMatchMinLength(min: number): R;
+  toMatchWordCount(options: { min?: number; max?: number }): R;
+  toMatchPromptRegex(pattern: RegExp | string): R;
+  toBeValidJson(): R;
+  toMatchJsonSchema(schema: Record<string, string>): R;
+  toMatchLevenshtein(expected: string, threshold?: number): R;
+  toMatchRouge1(reference: string, threshold?: number): R;
+  toMatchBleu(reference: string, threshold?: number): R;
+}

--- a/tests/matchers/index.test.ts
+++ b/tests/matchers/index.test.ts
@@ -1,0 +1,209 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { extendExpect, type PromptCanaryMatchers } from '../../src/matchers/index.js';
+
+declare module 'vitest' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface Assertion<T> extends PromptCanaryMatchers<T> {}
+}
+
+beforeAll(() => {
+  extendExpect(expect as unknown as Parameters<typeof extendExpect>[0]);
+});
+
+describe('expect.extend matchers', () => {
+  describe('toContainPrompt', () => {
+    it('passes when content contains substring', () => {
+      expect('Your refund will arrive in 30 days').toContainPrompt('refund');
+    });
+
+    it('fails when content does not contain substring', () => {
+      expect(() => {
+        expect('Hello world').toContainPrompt('refund');
+      }).toThrow();
+    });
+
+    it('is case-insensitive', () => {
+      expect('REFUND policy').toContainPrompt('refund');
+    });
+  });
+
+  describe('toNotContainPrompt', () => {
+    it('passes when content does not contain substring', () => {
+      expect('Hello world').toNotContainPrompt('refund');
+    });
+
+    it('fails when content contains substring', () => {
+      expect(() => {
+        expect('Refund policy').toNotContainPrompt('refund');
+      }).toThrow();
+    });
+  });
+
+  describe('toStartWithPrompt', () => {
+    it('passes when content starts with prefix', () => {
+      expect('Hello World').toStartWithPrompt('Hello');
+    });
+
+    it('fails when content does not start with prefix', () => {
+      expect(() => {
+        expect('World Hello').toStartWithPrompt('Hello');
+      }).toThrow();
+    });
+  });
+
+  describe('toEndWithPrompt', () => {
+    it('passes when content ends with suffix', () => {
+      expect('Hello World').toEndWithPrompt('World');
+    });
+
+    it('fails when content does not end with suffix', () => {
+      expect(() => {
+        expect('World Hello').toEndWithPrompt('World');
+      }).toThrow();
+    });
+  });
+
+  describe('toContainAllPrompt', () => {
+    it('passes when all substrings found', () => {
+      expect('Hello World Test').toContainAllPrompt(['Hello', 'World']);
+    });
+
+    it('fails when some substrings missing', () => {
+      expect(() => {
+        expect('Hello World').toContainAllPrompt(['Hello', 'Missing']);
+      }).toThrow();
+    });
+  });
+
+  describe('toContainAnyPrompt', () => {
+    it('passes when at least one substring found', () => {
+      expect('Hello World').toContainAnyPrompt(['Missing', 'World']);
+    });
+
+    it('fails when no substrings found', () => {
+      expect(() => {
+        expect('Hello World').toContainAnyPrompt(['Missing', 'NotHere']);
+      }).toThrow();
+    });
+  });
+
+  describe('toMatchMaxLength', () => {
+    it('passes when within limit', () => {
+      expect('Hello').toMatchMaxLength(10);
+    });
+
+    it('fails when exceeds limit', () => {
+      expect(() => {
+        expect('Hello World').toMatchMaxLength(5);
+      }).toThrow();
+    });
+  });
+
+  describe('toMatchMinLength', () => {
+    it('passes when meets minimum', () => {
+      expect('Hello World').toMatchMinLength(5);
+    });
+
+    it('fails when too short', () => {
+      expect(() => {
+        expect('Hi').toMatchMinLength(5);
+      }).toThrow();
+    });
+  });
+
+  describe('toMatchWordCount', () => {
+    it('passes when within range', () => {
+      expect('one two three').toMatchWordCount({ min: 2, max: 5 });
+    });
+
+    it('fails when out of range', () => {
+      expect(() => {
+        expect('one').toMatchWordCount({ min: 3 });
+      }).toThrow();
+    });
+  });
+
+  describe('toMatchPromptRegex', () => {
+    it('passes when pattern matches', () => {
+      expect('Error code: 404').toMatchPromptRegex(/\d{3}/);
+    });
+
+    it('fails when pattern does not match', () => {
+      expect(() => {
+        expect('No numbers here').toMatchPromptRegex(/\d+/);
+      }).toThrow();
+    });
+  });
+
+  describe('toBeValidJson', () => {
+    it('passes for valid JSON', () => {
+      expect('{"key":"value"}').toBeValidJson();
+    });
+
+    it('fails for invalid JSON', () => {
+      expect(() => {
+        expect('not json').toBeValidJson();
+      }).toThrow();
+    });
+  });
+
+  describe('toMatchJsonSchema', () => {
+    it('passes when schema matches', () => {
+      expect('{"name":"test","age":25}').toMatchJsonSchema({ name: 'string', age: 'number' });
+    });
+
+    it('fails when schema does not match', () => {
+      expect(() => {
+        expect('{"name":"test"}').toMatchJsonSchema({ name: 'string', age: 'number' });
+      }).toThrow();
+    });
+  });
+
+  describe('toMatchLevenshtein', () => {
+    it('passes when score meets threshold', () => {
+      expect('hello world').toMatchLevenshtein('hello world', 0.9);
+    });
+
+    it('fails when score below threshold', () => {
+      expect(() => {
+        expect('abc').toMatchLevenshtein('xyz', 0.5);
+      }).toThrow();
+    });
+  });
+
+  describe('toMatchRouge1', () => {
+    it('passes when score meets threshold', () => {
+      expect('the cat sat on the mat').toMatchRouge1('the cat sat', 0.5);
+    });
+
+    it('fails when score below threshold', () => {
+      expect(() => {
+        expect('completely different').toMatchRouge1('the cat sat on the mat', 0.8);
+      }).toThrow();
+    });
+  });
+
+  describe('toMatchBleu', () => {
+    it('passes when score meets threshold', () => {
+      expect('the cat sat on the mat').toMatchBleu('the cat sat on the mat', 0.8);
+    });
+
+    it('fails when score below threshold', () => {
+      expect(() => {
+        expect('completely different text here').toMatchBleu('the cat sat on the mat', 0.8);
+      }).toThrow();
+    });
+  });
+
+  describe('.not support', () => {
+    it('supports .not for negation', () => {
+      expect('Hello world').not.toContainPrompt('refund');
+    });
+
+    it('negation fails when match found', () => {
+      expect(() => {
+        expect('Hello world').not.toContainPrompt('Hello');
+      }).toThrow();
+    });
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/cli/index.ts', 'src/index.ts'],
+  entry: ['src/cli/index.ts', 'src/index.ts', 'src/matchers/index.ts'],
   format: ['esm'],
   dts: true,
   clean: true,


### PR DESCRIPTION
## Summary

- Ships 15 `expect.extend()` custom matchers for Vitest and Jest integration
- New subpath export: `promptcanary/matchers` with `extendExpect()` setup function
- Matchers: `toContainPrompt`, `toNotContainPrompt`, `toStartWithPrompt`, `toEndWithPrompt`, `toContainAllPrompt`, `toContainAnyPrompt`, `toMatchMaxLength`, `toMatchMinLength`, `toMatchWordCount`, `toMatchPromptRegex`, `toBeValidJson`, `toMatchJsonSchema`, `toMatchLevenshtein`, `toMatchRouge1`, `toMatchBleu`
- Exports `PromptCanaryMatchers<R>` interface for TypeScript module augmentation
- `.not` negation works automatically via Vitest/Jest
- 33 tests covering all matchers, negation, and pass/fail cases

Closes #128
