### PR TITLE
feat: add Ollama provider for local model testing

### DIFF
--- a/src/core/runner/providers/ollama.ts
+++ b/src/core/runner/providers/ollama.ts
@@ -1,0 +1,98 @@
+import OpenAI from 'openai';
+import type { LLMResponse, ProviderConfig } from '../../../types/index.js';
+import { ProviderError, TimeoutError } from '../../../types/index.js';
+import { registerProvider } from './base.js';
+import type { LLMProvider } from './base.js';
+
+const MAX_ATTEMPTS = 3;
+const DEFAULT_BASE_URL = 'http://localhost:11434/v1';
+
+export class OllamaProvider implements LLMProvider {
+  public readonly name = 'ollama';
+
+  public async execute(prompt: string, config: ProviderConfig): Promise<LLMResponse> {
+    const baseUrl = config.base_url ?? process.env.OLLAMA_BASE_URL ?? DEFAULT_BASE_URL;
+    const apiUrl = baseUrl.endsWith('/v1') ? baseUrl : `${baseUrl}/v1`;
+
+    const timeoutMs = config.timeout_ms;
+    const client = new OpenAI({
+      apiKey: 'ollama',
+      baseURL: apiUrl,
+    });
+
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+      const startedAt = Date.now();
+      const controller = new AbortController();
+      const timer = setTimeout(() => {
+        controller.abort();
+      }, timeoutMs);
+
+      try {
+        const completion = await client.chat.completions.create(
+          {
+            model: config.model,
+            messages: [{ role: 'user', content: prompt }],
+            temperature: config.temperature,
+            max_tokens: config.max_tokens,
+          },
+          {
+            signal: controller.signal,
+          },
+        );
+
+        const content = completion.choices[0]?.message?.content ?? '';
+        const usage = completion.usage;
+
+        return {
+          content,
+          model: completion.model,
+          provider: this.name,
+          latency_ms: Date.now() - startedAt,
+          token_usage: {
+            prompt: usage?.prompt_tokens ?? 0,
+            completion: usage?.completion_tokens ?? 0,
+          },
+          timestamp: new Date(),
+        };
+      } catch (error: unknown) {
+        if (controller.signal.aborted) {
+          throw new TimeoutError(this.name, timeoutMs);
+        }
+
+        if (attempt === MAX_ATTEMPTS) {
+          throw new ProviderError(
+            `Ollama request failed after ${String(MAX_ATTEMPTS)} attempts: ${getErrorMessage(error)}`,
+            this.name,
+            toError(error),
+          );
+        }
+
+        await delay(2 ** (attempt - 1) * 1000);
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+
+    throw new ProviderError('Ollama request failed', this.name);
+  }
+}
+
+registerProvider('ollama', new OllamaProvider());
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+function toError(error: unknown): Error | undefined {
+  return error instanceof Error ? error : undefined;
+}

--- a/src/schema/test-case.ts
+++ b/src/schema/test-case.ts
@@ -21,6 +21,7 @@ export const ProviderConfigSchema = z.object({
     .positive()
     .default(30000)
     .describe('Request timeout in milliseconds'),
+  base_url: z.string().optional().describe('Custom base URL for the provider API endpoint'),
 });
 
 /**

--- a/src/testing/compareModels.ts
+++ b/src/testing/compareModels.ts
@@ -22,6 +22,7 @@ export async function compareModels(
       model: modelConfig.model,
       messages: options.messages,
       apiKey: modelConfig.apiKey,
+      baseUrl: modelConfig.baseUrl,
       temperature: options.temperature,
       maxTokens: options.maxTokens,
       timeoutMs: options.timeoutMs,

--- a/src/testing/judge/index.ts
+++ b/src/testing/judge/index.ts
@@ -14,6 +14,8 @@ const providerApiKeyEnvMap: Record<NonNullable<JudgeOptions['provider']>, string
   openai: 'OPENAI_API_KEY',
   anthropic: 'ANTHROPIC_API_KEY',
   google: 'GOOGLE_API_KEY',
+  ollama: 'OLLAMA_BASE_URL',
+  'openai-compatible': 'OPENAI_API_KEY',
 };
 
 export function parseJudgeResponse(rawContent: string): JudgeResult {
@@ -85,6 +87,7 @@ export async function callJudge(options: { prompt: string } & JudgeOptions): Pro
     api_key_env: apiKeyEnv,
     timeout_ms: timeoutMs,
     temperature,
+    ...(options.baseUrl !== undefined ? { base_url: options.baseUrl } : {}),
   };
 
   try {

--- a/src/testing/testPrompt.ts
+++ b/src/testing/testPrompt.ts
@@ -15,6 +15,7 @@ import { ConfigError } from '../types/index.js';
 import '../core/runner/providers/openai.js';
 import '../core/runner/providers/anthropic.js';
 import '../core/runner/providers/google.js';
+import '../core/runner/providers/ollama.js';
 
 const DEFAULT_TIMEOUT_MS = 30000;
 const DEFAULT_CACHE_TTL = 86400;
@@ -25,6 +26,8 @@ const providerApiKeyEnvMap: Record<TestPromptOptions['provider'], string> = {
   openai: 'OPENAI_API_KEY',
   anthropic: 'ANTHROPIC_API_KEY',
   google: 'GOOGLE_API_KEY',
+  ollama: 'OLLAMA_BASE_URL',
+  'openai-compatible': 'OPENAI_API_KEY',
 };
 
 function getLastUserMessageContent(messages: TestPromptOptions['messages']): string {
@@ -107,6 +110,7 @@ async function executePrompt(
     timeout_ms: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
     ...(options.maxTokens !== undefined ? { max_tokens: options.maxTokens } : {}),
+    ...(options.baseUrl !== undefined ? { base_url: options.baseUrl } : {}),
   };
 
   if (options.apiKey !== undefined) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,10 +23,11 @@ export interface ChatMessage {
 }
 
 export interface TestPromptOptions {
-  provider: 'openai' | 'anthropic' | 'google';
+  provider: 'openai' | 'anthropic' | 'google' | 'ollama' | 'openai-compatible';
   model: string;
   messages: ChatMessage[];
   apiKey?: string;
+  baseUrl?: string;
   temperature?: number;
   maxTokens?: number;
   timeoutMs?: number;
@@ -131,9 +132,10 @@ export class ConfigError extends Error {
 }
 
 export interface JudgeOptions {
-  provider?: 'openai' | 'anthropic' | 'google';
+  provider?: 'openai' | 'anthropic' | 'google' | 'ollama' | 'openai-compatible';
   model?: string;
   apiKey?: string;
+  baseUrl?: string;
   temperature?: number;
   timeoutMs?: number;
 }
@@ -194,9 +196,10 @@ export interface MultiRunAssertionResult {
 }
 
 export interface CompareModelsModelConfig {
-  provider: 'openai' | 'anthropic' | 'google';
+  provider: 'openai' | 'anthropic' | 'google' | 'ollama' | 'openai-compatible';
   model: string;
   apiKey?: string;
+  baseUrl?: string;
 }
 
 export interface CompareModelsOptions {

--- a/tests/core/runner/providers/ollama.test.ts
+++ b/tests/core/runner/providers/ollama.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProviderConfig } from '../../../../src/types/index.js';
+import { ProviderError, TimeoutError } from '../../../../src/types/index.js';
+import { OllamaProvider } from '../../../../src/core/runner/providers/ollama.js';
+
+const { createCompletionMock, openAIConstructorMock } = vi.hoisted(() => {
+  const createCompletionMock = vi.fn();
+  const openAIConstructorMock = vi.fn(function OpenAIMock() {
+    return {
+      chat: {
+        completions: {
+          create: createCompletionMock,
+        },
+      },
+    };
+  });
+
+  return { createCompletionMock, openAIConstructorMock };
+});
+
+vi.mock('openai', () => ({
+  default: openAIConstructorMock,
+}));
+
+const config: ProviderConfig = {
+  name: 'ollama',
+  model: 'llama3.2',
+  api_key_env: 'OLLAMA_BASE_URL',
+  timeout_ms: 30000,
+};
+
+describe('OllamaProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(process.env, 'OLLAMA_BASE_URL');
+    vi.useRealTimers();
+  });
+
+  it('executes prompt and returns normalized response', async () => {
+    createCompletionMock.mockResolvedValue({
+      model: 'llama3.2',
+      choices: [{ message: { content: 'local model answer' } }],
+      usage: { prompt_tokens: 8, completion_tokens: 16 },
+    });
+
+    const provider = new OllamaProvider();
+    const result = await provider.execute('Hello', config);
+
+    expect(openAIConstructorMock).toHaveBeenCalledWith({
+      apiKey: 'ollama',
+      baseURL: 'http://localhost:11434/v1',
+    });
+    expect(result.content).toBe('local model answer');
+    expect(result.model).toBe('llama3.2');
+    expect(result.provider).toBe('ollama');
+    expect(result.token_usage).toEqual({ prompt: 8, completion: 16 });
+  });
+
+  it('uses default base URL when none is provided', async () => {
+    createCompletionMock.mockResolvedValue({
+      model: 'llama3.2',
+      choices: [{ message: { content: 'ok' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 2 },
+    });
+
+    const provider = new OllamaProvider();
+    await provider.execute('Hello', config);
+
+    expect(openAIConstructorMock).toHaveBeenCalledWith({
+      apiKey: 'ollama',
+      baseURL: 'http://localhost:11434/v1',
+    });
+  });
+
+  it('uses OLLAMA_BASE_URL environment variable when set', async () => {
+    process.env.OLLAMA_BASE_URL = 'http://remote-host:11434';
+    createCompletionMock.mockResolvedValue({
+      model: 'llama3.2',
+      choices: [{ message: { content: 'ok' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 2 },
+    });
+
+    const provider = new OllamaProvider();
+    await provider.execute('Hello', config);
+
+    expect(openAIConstructorMock).toHaveBeenCalledWith({
+      apiKey: 'ollama',
+      baseURL: 'http://remote-host:11434/v1',
+    });
+  });
+
+  it('uses base_url from config when provided', async () => {
+    createCompletionMock.mockResolvedValue({
+      model: 'llama3.2',
+      choices: [{ message: { content: 'ok' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 2 },
+    });
+
+    const provider = new OllamaProvider();
+    await provider.execute('Hello', {
+      ...config,
+      base_url: 'http://custom-host:11434',
+    });
+
+    expect(openAIConstructorMock).toHaveBeenCalledWith({
+      apiKey: 'ollama',
+      baseURL: 'http://custom-host:11434/v1',
+    });
+  });
+
+  it('does not append /v1 when base_url already ends with /v1', async () => {
+    createCompletionMock.mockResolvedValue({
+      model: 'llama3.2',
+      choices: [{ message: { content: 'ok' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 2 },
+    });
+
+    const provider = new OllamaProvider();
+    await provider.execute('Hello', {
+      ...config,
+      base_url: 'http://custom-host:11434/v1',
+    });
+
+    expect(openAIConstructorMock).toHaveBeenCalledWith({
+      apiKey: 'ollama',
+      baseURL: 'http://custom-host:11434/v1',
+    });
+  });
+
+  it('does not require an API key', async () => {
+    createCompletionMock.mockResolvedValue({
+      model: 'llama3.2',
+      choices: [{ message: { content: 'no key needed' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 2 },
+    });
+
+    const provider = new OllamaProvider();
+    const result = await provider.execute('Hello', config);
+
+    expect(result.content).toBe('no key needed');
+    expect(openAIConstructorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: 'ollama' }),
+    );
+  });
+
+  it('retries transient failures with exponential backoff', async () => {
+    vi.useFakeTimers();
+    createCompletionMock
+      .mockRejectedValueOnce(new Error('temporary-1'))
+      .mockRejectedValueOnce(new Error('temporary-2'))
+      .mockResolvedValueOnce({
+        model: 'llama3.2',
+        choices: [{ message: { content: 'recovered' } }],
+        usage: { prompt_tokens: 1, completion_tokens: 2 },
+      });
+
+    const provider = new OllamaProvider();
+    const pending = provider.execute('Hello', config);
+
+    await vi.runAllTimersAsync();
+    const result = await pending;
+
+    expect(createCompletionMock).toHaveBeenCalledTimes(3);
+    expect(result.content).toBe('recovered');
+  });
+
+  it('throws ProviderError after max retries exhausted', async () => {
+    vi.useFakeTimers();
+    createCompletionMock
+      .mockRejectedValueOnce(new Error('fail-1'))
+      .mockRejectedValueOnce(new Error('fail-2'))
+      .mockRejectedValueOnce(new Error('fail-3'));
+
+    const provider = new OllamaProvider();
+    const pending = provider.execute('Hello', config);
+    const assertion = expect(pending).rejects.toBeInstanceOf(ProviderError);
+
+    await vi.runAllTimersAsync();
+    await assertion;
+  });
+
+  it('throws TimeoutError when request aborts on timeout', async () => {
+    vi.useFakeTimers();
+    createCompletionMock.mockImplementation(
+      (_payload: unknown, options?: { signal?: AbortSignal }) =>
+        new Promise((_, reject: (reason?: unknown) => void) => {
+          options?.signal?.addEventListener('abort', () => {
+            reject(new Error('aborted'));
+          });
+        }),
+    );
+
+    const provider = new OllamaProvider();
+    const pending = provider.execute('Hello', { ...config, timeout_ms: 10 });
+    const assertion = expect(pending).rejects.toBeInstanceOf(TimeoutError);
+
+    await vi.advanceTimersByTimeAsync(10);
+    await assertion;
+  });
+
+  it('handles empty completion content gracefully', async () => {
+    createCompletionMock.mockResolvedValue({
+      model: 'llama3.2',
+      choices: [{ message: { content: null } }],
+      usage: { prompt_tokens: 1, completion_tokens: 0 },
+    });
+
+    const provider = new OllamaProvider();
+    const result = await provider.execute('Hello', config);
+
+    expect(result.content).toBe('');
+  });
+
+  it('handles missing usage data gracefully', async () => {
+    createCompletionMock.mockResolvedValue({
+      model: 'llama3.2',
+      choices: [{ message: { content: 'ok' } }],
+      usage: null,
+    });
+
+    const provider = new OllamaProvider();
+    const result = await provider.execute('Hello', config);
+
+    expect(result.token_usage).toEqual({ prompt: 0, completion: 0 });
+  });
+
+  it('config base_url takes precedence over env var', async () => {
+    process.env.OLLAMA_BASE_URL = 'http://env-host:11434';
+    createCompletionMock.mockResolvedValue({
+      model: 'llama3.2',
+      choices: [{ message: { content: 'ok' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 2 },
+    });
+
+    const provider = new OllamaProvider();
+    await provider.execute('Hello', {
+      ...config,
+      base_url: 'http://config-host:11434/v1',
+    });
+
+    expect(openAIConstructorMock).toHaveBeenCalledWith({
+      apiKey: 'ollama',
+      baseURL: 'http://config-host:11434/v1',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `OllamaProvider` that reuses the OpenAI SDK against Ollama's OpenAI-compatible API at `localhost:11434/v1`, requiring no API key
- Add `baseUrl` option to `TestPromptOptions`, `CompareModelsModelConfig`, and `JudgeOptions` for custom endpoint configuration
- Add `base_url` field to `ProviderConfig` schema and thread it through `testPrompt`, `compareModels`, and `judge`
- Add `'ollama'` and `'openai-compatible'` to all provider type unions (preparing for #127)
- 12 tests covering default/custom/env base URL, retry, timeout, precedence, and edge cases

Closes #124