### PR TITLE
feat: add generic OpenAI-compatible provider

### DIFF
--- a/src/core/runner/providers/openai-compatible.ts
+++ b/src/core/runner/providers/openai-compatible.ts
@@ -1,0 +1,141 @@
+import OpenAI from 'openai';
+import type { LLMResponse, ProviderConfig } from '../../../types/index.js';
+import { ProviderError, RateLimitError, TimeoutError } from '../../../types/index.js';
+import { registerProvider } from './base.js';
+import type { LLMProvider } from './base.js';
+
+const MAX_ATTEMPTS = 3;
+
+export class OpenAICompatibleProvider implements LLMProvider {
+  public readonly name = 'openai-compatible';
+
+  public async execute(prompt: string, config: ProviderConfig): Promise<LLMResponse> {
+    if (!config.base_url) {
+      throw new ProviderError('baseUrl is required for the openai-compatible provider', this.name);
+    }
+
+    const apiKey = process.env[config.api_key_env];
+    if (!apiKey) {
+      throw new ProviderError(
+        `Missing API key in environment variable: ${config.api_key_env}`,
+        this.name,
+      );
+    }
+
+    const timeoutMs = config.timeout_ms;
+    const client = new OpenAI({
+      apiKey,
+      baseURL: config.base_url,
+    });
+
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+      const startedAt = Date.now();
+      const controller = new AbortController();
+      const timer = setTimeout(() => {
+        controller.abort();
+      }, timeoutMs);
+
+      try {
+        const completion = await client.chat.completions.create(
+          {
+            model: config.model,
+            messages: [{ role: 'user', content: prompt }],
+            temperature: config.temperature,
+            max_tokens: config.max_tokens,
+          },
+          {
+            signal: controller.signal,
+          },
+        );
+
+        const content = completion.choices[0]?.message?.content ?? '';
+        const usage = completion.usage;
+
+        return {
+          content,
+          model: completion.model,
+          provider: this.name,
+          latency_ms: Date.now() - startedAt,
+          token_usage: {
+            prompt: usage?.prompt_tokens ?? 0,
+            completion: usage?.completion_tokens ?? 0,
+          },
+          timestamp: new Date(),
+        };
+      } catch (error: unknown) {
+        if (controller.signal.aborted) {
+          throw new TimeoutError(this.name, timeoutMs);
+        }
+
+        if (hasStatus(error, 429)) {
+          throw new RateLimitError(this.name, extractRetryAfterMs(error));
+        }
+
+        if (attempt === MAX_ATTEMPTS) {
+          throw new ProviderError(
+            `OpenAI-compatible request failed after ${String(MAX_ATTEMPTS)} attempts: ${getErrorMessage(error)}`,
+            this.name,
+            toError(error),
+          );
+        }
+
+        await delay(2 ** (attempt - 1) * 1000);
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+
+    throw new ProviderError('OpenAI-compatible request failed', this.name);
+  }
+}
+
+registerProvider('openai-compatible', new OpenAICompatibleProvider());
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function hasStatus(error: unknown, statusCode: number): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  if ('status' in error && typeof error.status === 'number') {
+    return error.status === statusCode;
+  }
+
+  return false;
+}
+
+function extractRetryAfterMs(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object') {
+    return undefined;
+  }
+
+  if ('headers' in error && error.headers && typeof error.headers === 'object') {
+    const headers = error.headers as Record<string, unknown>;
+    const retryAfter = headers['retry-after'];
+    if (typeof retryAfter === 'string') {
+      const seconds = Number.parseInt(retryAfter, 10);
+      if (!Number.isNaN(seconds)) {
+        return seconds * 1000;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+function toError(error: unknown): Error | undefined {
+  return error instanceof Error ? error : undefined;
+}

--- a/src/testing/testPrompt.ts
+++ b/src/testing/testPrompt.ts
@@ -16,6 +16,7 @@ import '../core/runner/providers/openai.js';
 import '../core/runner/providers/anthropic.js';
 import '../core/runner/providers/google.js';
 import '../core/runner/providers/ollama.js';
+import '../core/runner/providers/openai-compatible.js';
 
 const DEFAULT_TIMEOUT_MS = 30000;
 const DEFAULT_CACHE_TTL = 86400;

--- a/tests/core/runner/providers/openai-compatible.test.ts
+++ b/tests/core/runner/providers/openai-compatible.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProviderConfig } from '../../../../src/types/index.js';
+import { ProviderError, RateLimitError, TimeoutError } from '../../../../src/types/index.js';
+import { OpenAICompatibleProvider } from '../../../../src/core/runner/providers/openai-compatible.js';
+
+const { createCompletionMock, openAIConstructorMock } = vi.hoisted(() => {
+  const createCompletionMock = vi.fn();
+  const openAIConstructorMock = vi.fn(function OpenAIMock() {
+    return {
+      chat: {
+        completions: {
+          create: createCompletionMock,
+        },
+      },
+    };
+  });
+
+  return { createCompletionMock, openAIConstructorMock };
+});
+
+vi.mock('openai', () => ({
+  default: openAIConstructorMock,
+}));
+
+const config: ProviderConfig = {
+  name: 'openai-compatible',
+  model: 'llama-3.1-70b-versatile',
+  api_key_env: 'TEST_COMPATIBLE_KEY',
+  timeout_ms: 30000,
+  base_url: 'https://api.groq.com/openai/v1',
+};
+
+describe('OpenAICompatibleProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.TEST_COMPATIBLE_KEY = 'test-groq-key';
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(process.env, 'TEST_COMPATIBLE_KEY');
+    vi.useRealTimers();
+  });
+
+  it('executes prompt with custom baseURL and apiKey', async () => {
+    createCompletionMock.mockResolvedValue({
+      model: 'llama-3.1-70b-versatile',
+      choices: [{ message: { content: 'groq response' } }],
+      usage: { prompt_tokens: 10, completion_tokens: 20 },
+    });
+
+    const provider = new OpenAICompatibleProvider();
+    const result = await provider.execute('Hello', config);
+
+    expect(openAIConstructorMock).toHaveBeenCalledWith({
+      apiKey: 'test-groq-key',
+      baseURL: 'https://api.groq.com/openai/v1',
+    });
+    expect(result.content).toBe('groq response');
+    expect(result.model).toBe('llama-3.1-70b-versatile');
+    expect(result.provider).toBe('openai-compatible');
+    expect(result.token_usage).toEqual({ prompt: 10, completion: 20 });
+  });
+
+  it('throws ProviderError when baseUrl is missing', async () => {
+    const noBaseUrlConfig: ProviderConfig = {
+      name: 'openai-compatible',
+      model: 'some-model',
+      api_key_env: 'TEST_COMPATIBLE_KEY',
+      timeout_ms: 30000,
+    };
+
+    const provider = new OpenAICompatibleProvider();
+
+    await expect(provider.execute('Hello', noBaseUrlConfig)).rejects.toThrow(
+      'baseUrl is required for the openai-compatible provider',
+    );
+    await expect(provider.execute('Hello', noBaseUrlConfig)).rejects.toBeInstanceOf(ProviderError);
+  });
+
+  it('throws ProviderError when API key is missing', async () => {
+    Reflect.deleteProperty(process.env, 'TEST_COMPATIBLE_KEY');
+    const provider = new OpenAICompatibleProvider();
+
+    await expect(provider.execute('Hello', config)).rejects.toThrow(
+      'Missing API key in environment variable: TEST_COMPATIBLE_KEY',
+    );
+    await expect(provider.execute('Hello', config)).rejects.toBeInstanceOf(ProviderError);
+  });
+
+  it('throws RateLimitError on 429 responses', async () => {
+    createCompletionMock.mockRejectedValue({ status: 429 });
+    const provider = new OpenAICompatibleProvider();
+
+    await expect(provider.execute('Hello', config)).rejects.toBeInstanceOf(RateLimitError);
+  });
+
+  it('retries transient failures with exponential backoff', async () => {
+    vi.useFakeTimers();
+    createCompletionMock
+      .mockRejectedValueOnce(new Error('temporary-1'))
+      .mockRejectedValueOnce(new Error('temporary-2'))
+      .mockResolvedValueOnce({
+        model: 'llama-3.1-70b-versatile',
+        choices: [{ message: { content: 'recovered' } }],
+        usage: { prompt_tokens: 1, completion_tokens: 2 },
+      });
+
+    const provider = new OpenAICompatibleProvider();
+    const pending = provider.execute('Hello', config);
+
+    await vi.runAllTimersAsync();
+    const result = await pending;
+
+    expect(createCompletionMock).toHaveBeenCalledTimes(3);
+    expect(result.content).toBe('recovered');
+  });
+
+  it('throws ProviderError after max retries exhausted', async () => {
+    vi.useFakeTimers();
+    createCompletionMock
+      .mockRejectedValueOnce(new Error('fail-1'))
+      .mockRejectedValueOnce(new Error('fail-2'))
+      .mockRejectedValueOnce(new Error('fail-3'));
+
+    const provider = new OpenAICompatibleProvider();
+    const pending = provider.execute('Hello', config);
+    const assertion = expect(pending).rejects.toBeInstanceOf(ProviderError);
+
+    await vi.runAllTimersAsync();
+    await assertion;
+  });
+
+  it('throws TimeoutError when request aborts on timeout', async () => {
+    vi.useFakeTimers();
+    createCompletionMock.mockImplementation(
+      (_payload: unknown, options?: { signal?: AbortSignal }) =>
+        new Promise((_, reject: (reason?: unknown) => void) => {
+          options?.signal?.addEventListener('abort', () => {
+            reject(new Error('aborted'));
+          });
+        }),
+    );
+
+    const provider = new OpenAICompatibleProvider();
+    const pending = provider.execute('Hello', { ...config, timeout_ms: 10 });
+    const assertion = expect(pending).rejects.toBeInstanceOf(TimeoutError);
+
+    await vi.advanceTimersByTimeAsync(10);
+    await assertion;
+  });
+
+  it('handles empty completion content gracefully', async () => {
+    createCompletionMock.mockResolvedValue({
+      model: 'llama-3.1-70b-versatile',
+      choices: [{ message: { content: null } }],
+      usage: { prompt_tokens: 1, completion_tokens: 0 },
+    });
+
+    const provider = new OpenAICompatibleProvider();
+    const result = await provider.execute('Hello', config);
+
+    expect(result.content).toBe('');
+  });
+
+  it('handles missing usage data gracefully', async () => {
+    createCompletionMock.mockResolvedValue({
+      model: 'llama-3.1-70b-versatile',
+      choices: [{ message: { content: 'ok' } }],
+      usage: null,
+    });
+
+    const provider = new OpenAICompatibleProvider();
+    const result = await provider.execute('Hello', config);
+
+    expect(result.token_usage).toEqual({ prompt: 0, completion: 0 });
+  });
+
+  it('works with different OpenAI-compatible services', async () => {
+    createCompletionMock.mockResolvedValue({
+      model: 'deepseek-chat',
+      choices: [{ message: { content: 'deepseek response' } }],
+      usage: { prompt_tokens: 5, completion_tokens: 10 },
+    });
+
+    const deepseekConfig: ProviderConfig = {
+      ...config,
+      model: 'deepseek-chat',
+      base_url: 'https://api.deepseek.com/v1',
+    };
+
+    const provider = new OpenAICompatibleProvider();
+    const result = await provider.execute('Hello', deepseekConfig);
+
+    expect(openAIConstructorMock).toHaveBeenCalledWith({
+      apiKey: 'test-groq-key',
+      baseURL: 'https://api.deepseek.com/v1',
+    });
+    expect(result.model).toBe('deepseek-chat');
+    expect(result.content).toBe('deepseek response');
+  });
+
+  it('extracts retry-after header from rate limit errors', async () => {
+    createCompletionMock.mockRejectedValue({
+      status: 429,
+      headers: { 'retry-after': '30' },
+    });
+
+    const provider = new OpenAICompatibleProvider();
+
+    try {
+      await provider.execute('Hello', config);
+    } catch (error) {
+      expect(error).toBeInstanceOf(RateLimitError);
+      expect((error as RateLimitError).retry_after_ms).toBe(30000);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add `OpenAICompatibleProvider` for any service implementing the OpenAI chat completions API (Groq, Together, Fireworks, vLLM, LM Studio, Deepseek, Azure OpenAI, etc.)
- Requires both `baseUrl` and `apiKey` — no env var convention since it varies per service
- Includes retry with exponential backoff, rate limit detection with retry-after header extraction, and timeout handling
- 11 tests covering custom endpoints, missing config errors, rate limiting, retry, timeout, and multi-service compatibility

Closes #127